### PR TITLE
[코드리뷰] 강의 관점 수정 4건 — 항진 조건문/임베딩 await/평가지표 (강사 인용 인라인)

### DIFF
--- a/bench/src/gb-score.ts
+++ b/bench/src/gb-score.ts
@@ -24,13 +24,21 @@ function tokenize(s: string): string[] {
   return s.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length >= 3 && !STOP.has(t));
 }
 
-/** Token-level recall: fraction of gold-answer content tokens present in generated answer. */
+/**
+ * Token-level recall: fraction of distinct gold-answer content tokens present
+ * in the generated answer.
+ *
+ * Matching is exact token-set membership (word boundaries), NOT substring —
+ * otherwise "cat" would match "category"/"concatenate" and inflate recall.
+ * Gold tokens are de-duplicated so a repeated token can't skew the weight.
+ */
 function tokenAcc(answer: string, gold: string): number {
-  const goldTokens = tokenize(gold);
-  if (goldTokens.length === 0) return 0;
-  const ans = answer.toLowerCase();
-  const hits = goldTokens.filter((t) => ans.includes(t)).length;
-  return hits / goldTokens.length;
+  const goldTokens = new Set(tokenize(gold));
+  if (goldTokens.size === 0) return 0;
+  const ansTokens = new Set(tokenize(answer));
+  let hits = 0;
+  for (const t of goldTokens) if (ansTokens.has(t)) hits++;
+  return hits / goldTokens.size;
 }
 
 /** ROUGE-L F1 between answer and reference, using LCS over word sequences. */
@@ -79,7 +87,7 @@ function score(domain: string, retriever: string, dataDir: string, prefix = "cla
   }
   const N = ctx.length;
   console.log(
-    `  ${domain.padEnd(8)} ${retriever.padEnd(10)} ${prefix.padEnd(7)} N=${N}  ACC=${(accSum / N * 100).toFixed(2)}%  ROUGE-L=${(rougeSum / N * 100).toFixed(2)}%  (≥0.7 ACC: ${accFull}/${N})`,
+    `  ${domain.padEnd(8)} ${retriever.padEnd(10)} ${prefix.padEnd(7)} N=${N}  tok-recall=${(accSum / N * 100).toFixed(2)}%  ROUGE-L=${(rougeSum / N * 100).toFixed(2)}%  (≥0.7 tok-recall: ${accFull}/${N})`,
   );
 }
 
@@ -100,6 +108,10 @@ function main(): void {
     console.log();
   }
 
+  console.log(
+    "\n[주의] 위 tok-recall은 생성 답변의 '문자열 토큰 recall'이고, 아래 리더보드 Fact_ACC는 " +
+      "'LLM-judged correctness'라 측정 방식이 다릅니다. 같은 컬럼처럼 직접 비교하지 마세요.",
+  );
   console.log("\n=== Published GraphRAG-Bench Leaderboard (Fact_ACC / Fact_ROUGE-L) ===\n");
   console.log("Medical:");
   console.log("  G-reasoner          68.84 / 44.73");

--- a/packages/loader/src/kontext-agent.ts
+++ b/packages/loader/src/kontext-agent.ts
@@ -218,7 +218,7 @@ export class KontextAgent {
       const buildResult = await builder.build(docSources);
       newNodes = buildResult.nodes;
       newEdges = buildResult.edges;
-      this.expandGraph(newNodes, newEdges);
+      await this.expandGraph(newNodes, newEdges);
 
       // Classify documents into the newly-created nodes
       const classifier = new DocumentClassifier(this.router.traversalAdapter, this.templates);
@@ -226,7 +226,7 @@ export class KontextAgent {
       mappings = classification.mappings;
       unmapped = classification.unmapped;
       if (classification.newNodes.length > 0) {
-        this.expandGraph(classification.newNodes, []);
+        await this.expandGraph(classification.newNodes, []);
         newNodes = [...newNodes, ...classification.newNodes];
       }
     } else {
@@ -235,7 +235,7 @@ export class KontextAgent {
       newNodes = classification.newNodes;
       mappings = classification.mappings;
       unmapped = classification.unmapped;
-      this.expandGraph(newNodes, []);
+      await this.expandGraph(newNodes, []);
     }
 
     const classified = await this.indexClassifiedDocuments(mappings);
@@ -286,7 +286,10 @@ export class KontextAgent {
     return adapter?.dataSource ?? ("CUSTOM" as DataSource);
   }
 
-  private expandGraph(newNodes: readonly OntologyNode[], newEdges: readonly Edge[]): void {
+  private async expandGraph(
+    newNodes: readonly OntologyNode[],
+    newEdges: readonly Edge[],
+  ): Promise<void> {
     if (newNodes.length === 0 && newEdges.length === 0) return;
     const mergedNodes = new Map(this.graph.nodes);
     for (const node of newNodes) {
@@ -296,11 +299,12 @@ export class KontextAgent {
     this.graph = new OntologyGraph(mergedNodes, mergedEdges, this.graph.config);
     this.queryPipeline = this.buildQueryPipeline();
 
-    // embed new nodes async (fire-and-forget is fine here, but we await to keep tests deterministic)
+    // Embed new nodes and await before returning: the caller (autoSetup)
+    // proceeds to vector-based mapping/search right after, so the upserts
+    // must complete first to avoid a race on missing embeddings.
     if (this.vectorStore) {
       const vs = this.vectorStore;
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      Promise.all(
+      await Promise.all(
         newNodes.map(async (node) => {
           try {
             const emb = await vs.embed(node.description);

--- a/packages/loader/src/kontext-loader.ts
+++ b/packages/loader/src/kontext-loader.ts
@@ -5,6 +5,7 @@ import {
   DefaultTokenEstimator,
   DepthType,
   IngestPipeline,
+  KeywordMappingStrategy,
   KoreanTokenEstimator,
   LLMMetaDocumentSelector,
   type MetaDocumentSelector,
@@ -186,9 +187,7 @@ export class KontextLoader {
     // Mapping strategy
     const mappingStrategy = vectorStore
       ? new VectorMappingStrategy(vectorStore)
-      : (await import("@kontext-brain/core")).KeywordMappingStrategy.prototype.constructor
-        ? new (await import("@kontext-brain/core")).KeywordMappingStrategy()
-        : new (await import("@kontext-brain/core")).KeywordMappingStrategy();
+      : new KeywordMappingStrategy();
 
     // Meta selector
     const metaSelector: MetaDocumentSelector =


### PR DESCRIPTION
## 📋 인프런 강의 관점 코드리뷰 — 실제 수정 + 강사 인용 근거

인프런 수강 강의를 리뷰 렌즈로 삼아 발견한 문제 중 **명확히 고쳐지는 4건을 실제로 수정**한 PR입니다. 각 변경의 "왜 이렇게 고쳤는지"는 **변경 라인의 인라인 코멘트**에 강의 영상 링크와 강사 발언 인용으로 달아두었습니다(근거를 강의로 직접 재확인 가능).

### 리뷰 렌즈
- **헥사고날 아키텍처 / 코드 품질** — 토비의 클린 스프링 (courseId=336073, 강사: 토비)
- **AI 에이전트 평가(Evaluation)** — 안정적인 AI 에이전트 평가 (courseId=340324, 강사: 제이쓴) → `bench/` 대상

### 이번 PR에서 고친 것 (real diff)
| # | 파일 | 변경 | 근거 강의 |
|---|------|------|-----------|
| 🔴 A1 | `loader/kontext-loader.ts` | 항진 조건문(양쪽 분기 동일·dead code) 제거 + 정적 import | 코드 다듬기 (토비) |
| 🔴 A4 | `loader/kontext-agent.ts` | `expandGraph` 노드 임베딩을 실제로 `await`(주석-코드 불일치/레이스 해소) | 코드 다듬기 (토비) |
| 🔴 B1 | `bench/gb-score.ts` | 토큰 recall을 `ACC`로 표기해 LLM-judged 리더보드와 병치 → 라벨 명확화 + 주의 문구 | e2e 평가 (제이쓴) |
| 🟠 B2 | `bench/gb-score.ts` | substring 매칭(`"cat"`↔`"category"`)으로 인한 recall 과대평가 → 단어 경계 토큰 집합 교집합 | e2e 평가 (제이쓴) |

- 전체 패키지 `tsc --noEmit` 타입체크 통과(10/10).

### 후속 과제 (이번 PR 범위 밖 — 설계/인프라성이라 별도 논의 권장)
- 🟡 A2/A3 `NodeMappingRegistry`를 실제 전략 해소에 사용 + 기본 전략(vector/llm/hybrid) 등록 (포트 정의, 토비)
- 🟡 A5 `Entity`/`MetaDocument` 빈혈 도메인 → 생성 시점 불변식 강제 (도메인 모델 패턴, 토비)
- 🟢 A6 의존성 방향 강제 아키텍처 테스트(dependency-cruiser 등) (ArchUnit, 토비)
- 🟡 B3 두 스코어러의 지표 정의 불일치 → 공유 `metrics.ts` (Golden Dataset, 제이쓴)
- 🟡 B4 fallback 정규식 오답 처리 → LLM-judge (e2e 평가, 제이쓴)
- 🟢 B5 단일 실행 결론 → pass@k / pass^k·분산 보고 (pass^k, 제이쓴)
