### PR TITLE
feat: adaptive traversal scoring and direct-only evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 .env.local
 *.tsbuildinfo
 .turbo
+bench/data/rag-eval-v2/runs/

--- a/README.md
+++ b/README.md
@@ -90,9 +90,8 @@ ACL-accessible Evidence. It does not assume a DAG or a fixed number of lifts.
   organized under one ontology, not in three disconnected vector indexes.
 - **Predictable retrieval**: ontology routing is auditable — you can see
   exactly which nodes a query matched, then which docs under those nodes.
-- **Cost-tunable**: choose between fast extractive (no final LLM, ~1ms
-  latency, ~200 char context) and richer LLM-generated answers (1-8s,
-  200–1700 char context) per query.
+- **Cost-tunable**: choose between extractive retrieval with no final LLM and
+  richer LLM-generated answers per query.
 - **MCP-native**: built on the official Model Context Protocol SDK both as
   client (consume MCP servers) and as server (expose to AI agent hosts).
 - **Governed auto-setup**: the first setup session can build a small ontology.
@@ -175,8 +174,8 @@ pnpm test            # unit, contract, and integration tests
 ```bash
 pnpm --filter @kontext-brain/example-basic start       # in-process toy
 pnpm --filter @kontext-brain/example-auto-setup start  # mock MCP servers + autoSetup
-pnpm --filter @kontext-brain/bench start               # full 14-system benchmark (needs Ollama)
-pnpm --filter @kontext-brain/bench ralph               # short-form "Ralph loop"
+bench/node_modules/.bin/tsx bench/src/rag-eval-v2/cli.ts doctor  # inspect evaluation prerequisites
+pnpm --filter @kontext-brain/bench start               # legacy local benchmark (needs Ollama)
 ```
 
 ---
@@ -359,8 +358,8 @@ const res = await agent.query("backend authentication");
 
 ### Pattern C — extractive (no LLM at query time)
 
-For tech-docs QA where answers are literal sentences and you need
-sub-millisecond latency:
+For document QA where answers are literal sentences and you want to avoid an
+LLM call at query time:
 
 ```typescript
 import { ExtractiveRetriever } from "@kontext-brain/core";
@@ -466,855 +465,88 @@ connector is skipped rather than interpreted as deleting all of its documents.
 
 ---
 
-## Performance (benchmark)
-
-Local Ollama, deterministic (`temperature=0`), 12 tech docs across
-backend / frontend / ops / security, 8 factual queries with expected doc IDs
-and keyword fragments. Metrics computed per query, then averaged.
-
-```
-system           recall  keyword    ctx     latency    efficiency  ratio
-─────────────── ─────── ───────── ─────── ────────── ──────────── ─────────
-baseline (RAG)    0.875    0.823    1436     6707ms   7.48e-8       1.00x
-flat-kw           0.750    0.706    1720     7063ms   6.18e-8       0.83x
-v1-default        0.000    0.354      93    14141ms   0             0.00x   ← original bug
-v1-fixed          1.000    0.700     839    11793ms   7.07e-8       0.95x
-v2-keyword        1.000    0.875    1285     6974ms   9.77e-8       1.31x
-v3-vector         0.625    0.656    2575     9694ms   1.64e-8       0.22x
-v4-llm            1.000    0.938    1768    11389ms   4.66e-8       0.62x
-v5-compress       1.000    0.738     694     4740ms   2.24e-7       3.00x
-v9-rerank         1.000    0.844     904     6320ms   1.48e-7       1.97x
-v10-rerank+c      1.000    0.762     495     5118ms   3.01e-7       4.03x
-─── Ralph loop additions ───
-v13-sentence      1.000    0.813     217     1853ms   2.02e-6      26.99x   ← fair RAG winner
-v17-hybrid-ex     1.000    0.813     217     1887ms   1.98e-6      26.49x
-v12-extract       1.000    0.875     168       <1ms   2.68e-2  358,244x    ← extractive QA
-v16-proximity     1.000    0.875     206       <1ms   2.97e-2  397,895x    ← overall winner
-```
-
-`efficiency = recall × keyword_hit / (context_chars × latency_ms)` — higher is
-better. `ratio` is relative to the baseline.
-
-### Two classes of wins (read carefully)
-
-**1. Fair RAG comparison (v13-sentence, v17-hybrid-ex) — 27x baseline.**
-
-This is the defensible result. Both systems make exactly the same LLM and
-embedding calls per query (1× embed + 1× chat), so latency / cost
-differences come from kontext sending less context, not from skipping work.
-
-- Same answer quality on this corpus: kw 0.813 vs baseline 0.823 (within
-  1pp on 8 queries — statistically equivalent)
-- 85% smaller context (217 chars vs 1436)
-- 72% lower latency (1.85s vs 6.71s)
-
-**2. Extractive QA (v12-extract, v16-proximity) — ~400,000x is misleading.**
-
-These variants do **zero LLM calls** and zero network I/O. They return
-top-scored sentences from retrieved docs as the answer using pure in-memory
-keyword matching. The latency (<1ms) was independently sanity-checked: cold
-instances on novel queries land at 0.17–0.37ms, indistinguishable from a
-plain `Array.filter()` over the same data — confirming there's no caching
-artifact, just no work to do.
-
-The 400,000x ratio is therefore measuring **"Ollama round-trip vs JS string
-matching"**, not "better RAG." It's a real number but an apples-to-oranges
-comparison: extractive QA and RAG generation are different tasks. Treat
-this as: *"if your domain has answers as literal sentences in the corpus,
-you can sometimes skip the LLM entirely and serve answers in microseconds."*
-Don't read it as "kontext is 400,000× faster than vector RAG."
-
-When extractive breaks: q5 "rotate secrets" needs synthesis across 3
-scattered sentences in the corpus → both v12 and v16 score keyword-hit 0.00
-on that query. v13-sentence (with LLM) handles it correctly.
-
-`ExtractiveRetriever` lives in `@kontext-brain/core` so you can use it
-directly when latency/cost matter and your queries are extractive in nature
-(FAQ-style tech support, doc lookup, etc.).
-
-### Variant cheat-sheet
-
-| your need | use |
-|-----------|-----|
-| Highest answer quality, willing to pay LLM cost | `v4-llm` (kw 0.938, 1768 ctx, 11s) |
-| Best balance, drop-in replacement for vector RAG | `v9-rerank` (kw 0.844, 904 ctx, 6s) |
-| Cheapest per query | `v10-rerank+c` (kw 0.762, 495 ctx, 5s) |
-| Fastest with LLM in the loop | `v5-compress` (kw 0.738, 694 ctx, 4.7s) |
-| Fastest possible, extractive ok | `v16-proximity` / `ExtractiveRetriever` (kw 0.875, 206 ctx, <1ms) |
-| Don't know yet | `v2-keyword` (kw 0.875, 1285 ctx, 7s — same speed as baseline, better answers) |
-
-### What didn't help on this corpus
-
-Tracked honestly so you don't repeat the same experiments:
-
-- **HyDE** (v7): hypothetical-document embedding from a 1.5B LLM was too noisy
-  → recall dropped to 0.500. Likely useful with larger models.
-- **Query expansion** (v8): LLM-generated keyword expansion pulled in
-  irrelevant docs, growing context without improving answers.
-- **Hybrid keyword+vector mapping** (v6, v11): vector noise on 10-word node
-  descriptions overwhelmed keyword signal. Default `KeywordMapping` and
-  `LLMMapping` outperformed it.
-- **Vector-only mapping** (v3): bare similarity on tiny node descriptions had
-  recall 0.625 — worse than keyword.
-- **Original `DEFAULT_PIPELINE`** (v1): had a structural bug — graph depth
-  was confused with retrieval-stage order, so a leaf match never reached
-  META/CONTENT. **Fixed in this version**: the collector runs the same
-  N-layer stage sequence for each traversed node.
-
-### Real research dataset: SQuAD 2.0 (Round 7-8, Claude-Code-judged)
-
-Swapped the hand-crafted tech-docs corpus for a 30-query sample of SQuAD 2.0
-dev (Wikipedia paragraph QA, 66 distractor paragraphs). Auto-ontology from
-article titles, auto-extracted entities (capitalized phrases in Round 7,
-plus TF-IDF common-noun phrases in Round 8). **Claude Code manually judged
-each answer** for whether it contains the reference.
-
-**Round 7** — isolated variants:
-
-```
-system       claude-judge  auto-kw    ctx      latency
-baseline        80.0%       76.2%    1587ch    5076ms   ← winner
-entity          66.7%       68.2%     275ch       1ms
-bm25-map        53.3%       54.5%    1883ch    5154ms
-extractive      50.0%       50.7%     282ch       1ms
-kw-map          16.7%       20.5%    2320ch    7053ms
-```
-
-Round 7 said "on an unmodified research dataset, kontext loses to vector
-RAG on quality". Fair reading — kontext's proper-noun entity extractor
-couldn't handle concept-level queries ("biomass", "complexity theory"),
-and the auto-ontology from article titles had no semantic signal.
-
-**Round 8** — new `HybridRetriever` combining vector similarity + entity
-matching, with common-noun entities (IDF-ranked phrases) added to the
-vocab:
-
-```
-system       claude-judge  recall   auto-kw    ctx      latency
-hybrid          83.3%       0.967    0.795    1508ch    2454ms   ← NEW WINNER
-baseline        80.0%       0.900    0.762    1587ch    4849ms
-vector-docs     80.0%       0.900    0.762    1506ch    3879ms   (doc-level vector only)
-entity          66.7%       0.700    0.682     275ch       1ms
-bm25-map        53.3%       0.500    0.545    1883ch    4882ms
-extractive      50.0%       0.567    0.507     282ch       1ms
-kw-map          16.7%       0.100    0.205    2320ch    6639ms
-```
-
-`hybrid` beats the standard vector-RAG baseline on every metric:
-
-- **+3.3pp Claude Code judgment** (83.3% vs 80.0%)
-- **+6.7pp recall** (0.967 vs 0.900) — almost every query's reference doc retrieved
-- **+3.3pp auto keyword-hit** (0.795 vs 0.762)
-- **−49% latency** (2454ms vs 4849ms) — doc-level embedding is faster than chunk-level, entity pre-filter reduces vector search work
-- Roughly equal context (−5%)
-
-Full per-query judgment for Round 7: [`bench/data/squad-judge-report.md`](./bench/data/squad-judge-report.md).
-Round 8 uses the same file plus `bench/src/squad-results.json` with the hybrid column.
-
-**What changed between Round 7 and 8**:
-
-1. `HybridRetriever` in `@kontext-brain/core` — weighted ensemble:
-   ```
-   score(doc) = entityWeight * entity_overlap_norm + vectorWeight * vector_similarity
-   ```
-   Default entityWeight=0.4, vectorWeight=0.6. Each signal catches what the
-   other misses.
-2. Entity vocabulary extended with **common-noun phrases** (TF-IDF-ranked
-   unigrams/bigrams) alongside proper nouns. Covers queries like "biomass",
-   "exercise", "algorithm" that the proper-noun-only extractor missed.
-3. Doc-level embedding instead of chunking (SQuAD paragraphs are already
-   right-sized). Faster indexing + shorter query compute.
-4. BM25 body compression on the retrieved docs before LLM answer. Smaller
-   context → faster LLM generation.
-
-**Important**: the LLM didn't change. Same `qwen2.5:1.5b` on Ollama. The
-accuracy gain is purely from the retrieval pipeline — confirmation that
-the earlier "LLM is too small" hypothesis was wrong; the gap was retrieval,
-not model quality.
-
-### Round 10–11: pushing SQuAD accuracy above 83%
-
-After hybrid's 83.3% on SQuAD (Round 8), tried three ways to push higher:
-
-1. **Retrieval ensemble** (hybrid ∪ baseline docs) — no quality gain, 26% faster
-2. **Extract-then-answer** (2-stage LLM) — actually regressed to 60% (the 1.5B model truncates answers too aggressively on stage 2)
-3. **Bigger LLM** (`qwen2.5:3b`) — 83.3% with *different* failure pattern (fixes sthène+O₂ but breaks Article 102 and "in bays")
-
-Key observation: hybrid@1.5b wrong on {sq-1, sq-14, sq-24, sq-27, sq-28};
-hybrid@3b wrong on {sq-14, sq-16, sq-20, sq-24, sq-28}. Overlap is only 3
-queries, so an **answer-selection ensemble** that runs both and asks a
-third LLM to pick the better answer could theoretically reach 27/30 = 90%.
-
-Implemented this as `SquadKontextAnswerEnsemble`:
-
-```
-system          judged   auto-kw    ctx      latency
-baseline         80.0%    0.762    1587ch    5237ms
-hybrid           83.3%    0.795    1508ch    2569ms
-hybrid-3b        83.3%    0.756    1508ch   10336ms   (different failures)
-ans-ensemble     86.7%    0.812    1508ch   14704ms   ← NEW BEST
-oracle limit     90.0%    —        —        —
-```
-
-**+3.3pp over hybrid, +6.7pp over baseline.** Judge correctly picked the
-better answer on sq-1 (sthène), sq-16 (in bays), sq-27 (O₂); picked wrong
-on sq-20 (Article 102). Three remaining failures (sq-14 aerobic, sq-24
-belt animals, sq-28 proteins) need deeper fixes — better retrieval for the
-first two, negation-aware query rewriting for the third — neither is a
-judge problem.
-
-Cost: ~5.7× hybrid latency (runs 2× hybrid + judge call). Appropriate
-when answer quality matters and latency budget allows. For latency-bound
-serving, plain hybrid at 83.3% / 2.5s is still the better pick.
-
-### Round 10: attempted push to 90% — regressed, documented honestly
-
-Tried a 3-way `synthesis` variant: hybrid@1.5b + hybrid@3b +
-extractive-on-hybrid (top-scored verbatim sentence from retrieved docs),
-plus exclusion-pattern detection (`"besides X, what..."`) and prefix-match
-query expansion. The 3b judge picked from the three or used extractive as
-a grounding sentence.
-
-**Result: 24/30 = 80.0%, regressed 2 queries vs ans-ensemble.** The
-extractive grounding introduced noise — its verbatim sentence sometimes
-biased the judge toward the wrong candidate (sq-1 sthène, sq-16 "in bays").
-Targeted fixes for the 4 remaining ans-ensemble failures (sq-14 aerobic,
-sq-20 Article 102, sq-24 belt animals, sq-28 proteins) did not land:
-three are LLM-capacity failures where a same-class 3b judge cannot
-reliably overrule its own weaker variants, and one (sq-24) is a retriever
-edge case where vector similarity on short questions latches onto generic
-tokens.
-
-**Decision: ans-ensemble at 86.7% stays as the best.** Pushing past 90%
-on this 30-query sample appears blocked on LLM capacity (7B+ would likely
-clear sq-20 / sq-28) rather than pipeline design. The 3-layer ontology
-already retrieves the correct doc for 29/30 queries (recall 0.967); the
-loss is in the answerer. Full per-query analysis in
-[`bench/data/round10-report.md`](./bench/data/round10-report.md).
-
-### Round 11: second research dataset — HotpotQA multi-hop, honest regression
-
-SQuAD is single-hop (one gold paragraph per question). To stress-test on a
-different shape, added HotpotQA distractor dev set as a second research
-dataset — **every question needs TWO gold paragraphs**, often with
-compositional answers that don't appear verbatim anywhere.
-
-20-query HotpotQA sample, same Ollama stack:
-
-```
-system       recall  both-gold  keyword   ctx     latency
-baseline     0.650   0.450      0.467    1366ch    4474ms
-hybrid       0.600   0.350      0.469    1217ch    3757ms
-hybrid-3b    0.600   0.350      0.570    1217ch    8642ms
-ans-ensemble 0.600   0.350      0.520    1217ch   11279ms
-```
-
-**Claude-Code-judged accuracy: ~30%** (vs. 86.7% on SQuAD). Massive
-regression. The drop is the story.
-
-Three structural reasons:
-1. **Retrieval is single-query top-k** — it biases toward docs that match
-   the *whole* question, not each mentioned entity. `both-gold-hit` is
-   only 35%; in 65% of queries we're missing at least one gold doc.
-2. **1.5b/3b LLMs can't compose** — even when both gold docs land in
-   context, questions like "country of origin common to X and Y" need
-   set-intersection reasoning the model can't do reliably.
-3. **Single-hop architecture is the real problem**, not the LLM — fixing
-   (1) via entity-decomposed or iterative retrieval would likely lift
-   `both-gold-hit` from 35% to 65%+ and accuracy correspondingly.
-
-Takeaway: **SQuAD 86.7% does not generalize to multi-hop.** The framework's
-hybrid retriever is strong on single-hop but not multi-hop aware.
-Documenting this before any "production ready" claims is the whole point
-of running a second dataset. Full analysis: [`bench/data/round11-report.md`](./bench/data/round11-report.md).
-
-### N-layer pipeline (added Round 11)
-
-Moved from "3-layer fixed" to "N-layer configurable" as a first-class
-abstraction. `packages/core/src/query/n-layer.ts` adds `LayerExecutor`,
-discriminated `Candidate` union (`node | doc | chunk | entity | member`),
-`PipelineSpec`, and a runner with per-layer tracing. Validates adjacent
-layer input/output kinds at load time.
-
-3-layer (ontology → meta → content) stays as the default preset. New
-domains can now define their own — law 4-layer (domain → article →
-section → body), code graph 4-layer (repo → class → member → source),
-multi-hop retrieval as a layer, etc. Future work: implement the code-graph
-and multi-hop-retriever layers against this abstraction.
-
-### Round 12: Claude Code as the LLM — isolating the capacity variable
-
-To test whether the SQuAD ceiling (86.7%) and the HotpotQA collapse
-(~30%) were truly LLM-capacity-bound, we kept the retriever, index, and
-contexts identical and swapped only the answerer — Claude Code instead of
-Ollama qwen2.5:1.5b+3b. The `dump-contexts` / `score-claude` scripts
-make this reproducible.
-
-**Per-query judged accuracy (manual)**:
-
-| System | SQuAD 30q | HotpotQA 20q |
-|--------|-----------|--------------|
-| Ollama hybrid@1.5b | 80.0% | 25% |
-| Ollama ans-ensemble (1.5b+3b+judge) | 86.7% | 30% |
-| **Claude Code over same retrieval** | **96.7% (29/30)** | **85.0% (17/20)** |
-
-- SQuAD: **+10pp** over best Ollama
-- HotpotQA: **+55pp** over best Ollama
-
-All 1 SQuAD failure (sq-24 belt animals) and all 3 HotpotQA failures
-(hp-0, hp-4, hp-13) are **retrieval failures** — the required gold page
-was absent from the retrieved context. Claude Code correctly identified
-each as unretrievable rather than hallucinating.
-
-**Confirms Round 10 hypothesis**: the 86.7% SQuAD ceiling was LLM capacity,
-not pipeline design. On hardware that can run 7B+ or pay for API, the
-existing architecture gets 96.7% on SQuAD with no code changes.
-HotpotQA's 55pp gap is even larger because multi-hop questions demand
-composition the 3B model can't do.
-
-Full per-query analysis: [`bench/data/round12-report.md`](./bench/data/round12-report.md).
-
-### Round 13: kontext-brain hybrid vs vanilla vector RAG, LLM-equalized
-
-Swapping out the LLM proved that single-hop capacity was the bottleneck.
-Round 13 asks the complementary question: **given the same LLM (Claude),
-does kontext-brain's hybrid retriever actually beat a plain vector RAG
-baseline?**
-
-Both pipelines dump retrieved contexts for the same 30 SQuAD + 20
-HotpotQA queries with `nomic-embed-text` embeddings; Claude answers over
-the retrieved contexts for both. Only the retriever differs.
-
-**Judged accuracy**:
-
-| System | SQuAD 30q | HotpotQA 20q |
-|--------|-----------|--------------|
-| **vanilla vector RAG + Claude** | **27/30 = 90.0%** | **18/20 = 90.0%** |
-| **kontext-brain hybrid + Claude** | **29/30 = 96.7%** | 17/20 = 85.0% |
-| Δ (kontext − vanilla) | **+6.7pp** | **-5.0pp** |
-
-**Honest finding: no universal winner.**
-
-On **SQuAD (single-hop, entity-anchored)**, kontext-brain's hybrid
-retriever wins by finding gold docs that vanilla RAG missed — sq-22
-"Normandy" (entity match on proper noun), sq-29 "Pleurobrachia" (entity
-match on species name). The entity signal is a pure gain when the
-question anchors to a named thing.
-
-On **HotpotQA (multi-hop)**, vanilla RAG wins because **bridge/
-comparison questions have two entities**. The hybrid retriever's entity
-signal boosts one entity's page to the top and crowds out the second
-gold doc. Vanilla vector similarity, with no entity bias, sometimes
-surfaces both gold docs simultaneously. Examples where vanilla got both
-and hybrid got only one: hp-4 (Saab/Mach number), hp-6 (Schnellenberger/
-Miami Dolphins), hp-18 (Adorno/Lulu).
-
-**Implication**: the choice of retriever should depend on query shape.
-The N-layer abstraction (Round 11) was designed for exactly this — a
-production deployment classifies question shape and dispatches to the
-appropriate preset.
-
-| Query shape | Best retriever |
-|-------------|----------------|
-| Single-hop, entity-anchored | kontext-brain hybrid |
-| Multi-hop bridge/comparison | vanilla vector RAG (until per-entity decomposed retrieval is added) |
-| Structured predicate | attribute retrieval (100% F1) |
-
-Reproduce: `pnpm --filter @kontext-brain/bench dump-contexts-baseline` +
-`score-claude`. Full per-query analysis:
-[`bench/data/round13-report.md`](./bench/data/round13-report.md).
-
-### Round 14: multi-hop retriever — kontext-brain wins HotpotQA too (100%)
-
-Round 13 showed kontext-brain's hybrid retriever regressed vs vanilla RAG
-on multi-hop. Round 14 implemented a purpose-built **multi-hop
-retriever** that beats vanilla RAG decisively.
-
-Key finding during debugging: `nomic-embed-text` collapses on short
-entity queries — "Tom Petty" and "Traveling Wilburys" return the same
-top-5 docs. Semantic similarity is unusable for short entity names;
-BM25 with title-match boost is required.
-
-Multi-hop retriever design:
-1. Extract named entities from the question
-2. Per-entity BM25 with strong title-match boost (weight 1.0)
-3. Full-question vector search (weight 0.6)
-4. Full-question BM25 (weight 0.4)
-5. **Iterative 2-hop expansion**: extract capitalized phrases from top-5
-   retrieved docs' bodies (up to 2500 chars), re-query BM25 per hop entity
-6. Coverage guarantee: one doc per question-entity in final top-K
-
-Both-gold retrieval progression on HotpotQA (20 multi-hop queries):
-
-| Retriever | Both-gold | Avg recall |
-|-----------|-----------|------------|
-| vanilla vector RAG | 45% | 0.650 |
-| kontext-brain hybrid | 35% | 0.600 |
-| multi-hop (BM25, no hop-2) | 50% | 0.725 |
-| multi-hop (+ title-boost) | 70% | 0.850 |
-| multi-hop (+ hop-2 expansion) | 85% | 0.925 |
-| **multi-hop (final, k=6, snippet 2500)** | **100%** | **1.000** |
-
-**End-to-end HotpotQA accuracy (Claude as LLM, judged)**:
-
-| Retriever | Correct | Accuracy | Δ vs vanilla |
-|-----------|---------|----------|--------------|
-| vanilla RAG + Claude | 18/20 | 90.0% | — |
-| kontext-brain hybrid + Claude | 17/20 | 85.0% | -5.0pp |
-| **kontext-brain multi-hop + Claude** | **20/20** | **100.0%** | **+10.0pp** |
-
-### Final head-to-head — kontext-brain wins every bench
-
-| Bench | Best kontext-brain variant | Score | Best alternative | Δ |
-|-------|---------------------------|-------|------------------|---|
-| SQuAD 2.0 single-hop (Claude) | hybrid | **96.7%** | vanilla RAG 90.0% | **+6.7pp** |
-| HotpotQA multi-hop (Claude) | **multi-hop** | **100.0%** | vanilla RAG 90.0% | **+10.0pp** |
-| SQuAD 2.0 single-hop (Ollama) | ans-ensemble | 86.7% | vanilla RAG 80.0% | +6.7pp |
-| Structured filter queries | attribute retrieval | **100% F1** | vanilla RAG 58.8% F1 | **+41.2pp** |
-
-The framework's point was always **pluggable retrievers per query shape**.
-Round 14 validates that with a multi-hop retriever matching HotpotQA's
-bridge/comparison demands. Full per-query analysis:
-[`bench/data/round14-report.md`](./bench/data/round14-report.md).
-
-### Round 15: GraphRAG-Bench (ICLR'26) — vs LightRAG / HippoRAG2 / GraphRAG / Fast-GraphRAG
-
-**GraphRAG-Bench** (Xiang et al., arXiv:2506.05690, ICLR'26) is the
-reference benchmark for graph-based RAG systems. It evaluates LightRAG,
-HippoRAG2, Microsoft's GraphRAG (local + global) + Lazy-GraphRAG,
-Fast-GraphRAG, RAPTOR, KGP, StructRAG, KET-RAG, and others on the same
-corpora with the same eval script. Two domains: **Medical** (cancer-care
-corpus, 2062 questions) + **Novel** (20 literary works, 2010 questions).
-
-We loaded the official data, ran our retrievers (vanilla / hybrid /
-multi-hop) on a sampled N=30 Fact Retrieval subset per domain, and had
-Claude Code answer over the multi-hop-retrieved contexts.
-
-**Retrieval coverage** (auto, evidence-token recall):
-
-| Retriever | Medical | Novel |
-|-----------|---------|-------|
-| vanilla RAG | 0.811 | 0.525 |
-| kontext-brain hybrid | 0.852 | 0.684 |
-| **kontext-brain multi-hop** | **0.864** | **0.764** |
-
-**End-to-end vs published leaderboard** (Fact_ACC / Fact_ROUGE-L):
-
-Medical:
-| Rank | System | ACC | ROUGE-L |
-|------|--------|-----|---------|
-| —    | **kontext-brain mh + Claude (N=30 subset)** | **86.66** | **62.06** |
-| 1    | G-reasoner | 68.84 | 44.73 |
-| 3    | HippoRAG2 | 66.28 | 36.69 |
-| 5    | LightRAG | 63.32 | 37.19 |
-| 4    | Fast-GraphRAG | 60.93 | 31.04 |
-| 11   | Lazy-GraphRAG (Microsoft) | 60.25 | 31.66 |
-| 14   | MS-GraphRAG (local) | 38.63 | 26.80 |
-
-Novel:
-| Rank | System | ACC | ROUGE-L |
-|------|--------|-----|---------|
-| —    | **kontext-brain mh + Claude (N=30 subset)** | **90.00** | **45.33** |
-| 3    | HippoRAG2 | 60.14 | 31.35 |
-| 12   | LightRAG | 58.62 | 35.72 |
-| 4    | Fast-GraphRAG | 56.95 | 35.90 |
-| 5    | MS-GraphRAG (local) | 49.29 | 26.11 |
-
-**Honest caveats** (must read before citing):
-
-1. **Subset, not full benchmark** — N=30 per domain (≈1.5% of full set).
-2. **Different LLM** — leaderboard uses 7B-class open models; we used
-   Claude Code (much more capable). Higher LLM ceiling matters
-   (consistent with Round 12 finding).
-3. **Auto-graded ACC vs LLM-judged ACC** — leaderboard uses LLM-as-judge,
-   we used token recall. Token recall is permissive.
-4. **Fact Retrieval only** — leaderboard ranks by Average over Fact +
-   Reasoning + Summarize + Creative. We measured only the easiest task.
-5. **General-knowledge leakage** — 6/30 novel answers fell back to world
-   knowledge when retrieval missed; strict retrieval-only protocol would
-   drop novel ACC to ~70%.
-
-**What this actually demonstrates honestly**: kontext-brain's multi-hop
-retriever achieves the highest evidence-token coverage of the three
-retrievers we built (apples-to-apples on the same embedder + corpus),
-and a capable answerer over solid retrieval is competitive with
-research-grade graph RAG systems on fact retrieval. We make no claims
-about Reasoning / Summarization / Creative Generation tasks.
-
-Full analysis: [`bench/data/round15-report.md`](./bench/data/round15-report.md).
-
-### Round 16: confounders removed — controlled comparison
-
-Round 15 had 5 confounders (sample size, LLM, ACC metric, task scope,
-world-knowledge fallback). Round 16 controls 4 of the 5 (LLM is the
-only irreducible one without rerunning the leaderboard systems). Two
-new tables:
-
-**Retrieval-only comparison (LLM-free, fully controlled)**:
-
-```
-MEDICAL (N=30)
-retriever  | tokenCov | ≥0.7-cov | top1-hit
-vanilla    | 0.811    |   22/30  |   8/30
-hybrid     | 0.852    |   24/30  |   9/30
-multi-hop  | 0.864    |   24/30  |   6/30   ← best aggregate
-
-NOVEL (N=30)
-retriever  | tokenCov | ≥0.7-cov | top1-hit
-vanilla    | 0.525    |   10/30  |   4/30
-hybrid     | 0.684    |   17/30  |   6/30
-multi-hop  | 0.764    |   19/30  |   9/30   ← best on every metric
-```
-
-**Strict end-to-end** (fallback answers scored 0):
-
-```
-MEDICAL: ACC 86.62, ROUGE-L 62.06, fallback-rejected 0/30
-NOVEL:   ACC 57.63, ROUGE-L 35.44, fallback-rejected 10/30   ← honest
-```
-
-**vs leaderboard with LLM caveat explicit**:
-
-| Medical Fact_ACC | Score |
-|------------------|-------|
-| **kontext-brain mh + Claude (STRICT)** | **86.62** |
-| G-reasoner (Llama-8B, full N) | 68.84 |
-| HippoRAG2 (8B, full N) | 66.28 |
-| LightRAG (8B, full N) | 63.32 |
-| Fast-GraphRAG (8B, full N) | 60.93 |
-| MS-GraphRAG (local, 8B, full N) | 38.63 |
-
-| Novel Fact_ACC | Score |
-|----------------|-------|
-| HippoRAG2 (8B, full N) | 60.14 |
-| G-reasoner (8B, full N) | 60.07 |
-| RAG w/ rerank (8B, full N) | 60.92 |
-| LightRAG (8B, full N) | 58.62 |
-| **kontext-brain mh + Claude (STRICT)** | **57.63** |
-| Fast-GraphRAG (8B, full N) | 56.95 |
-| MS-GraphRAG local (8B, full N) | 49.29 |
-
-**Three honest statements**:
-
-1. **Retrieval (controlled)**: multi-hop has the best evidence coverage
-   of the three retrievers we built (+5pp medical, +24pp novel vs
-   vanilla RAG). This is the apples-to-apples result.
-
-2. **Medical end-to-end**: kontext-brain + Claude beats every leaderboard
-   entry by ≥18pp. This gap is **mostly Claude vs 8B**, not the retriever.
-
-3. **Novel end-to-end**: kontext-brain + Claude lands **in the middle of
-   the pack** (-2.5pp behind HippoRAG2/G-reasoner). Retrieval failures
-   (10/30 fallbacks) bottleneck novel — narrative content is harder than
-   fact-dense medical text. **HippoRAG2 and G-reasoner beat us here.**
-
-What we still cannot claim: 4-task average, full-set N, retriever
-superiority on tasks other than measured, LLM-judge ACC.
-
-Full controlled-comparison analysis: [`bench/data/round16-report.md`](./bench/data/round16-report.md).
-
-### Round 17: 8B apples-to-apples vs leaderboard, chunking matched
-
-Round 16's "different LLM" was the unresolved confounder. Round 17
-controls it by switching from Claude to **Llama-3.1-8B-Instruct** as
-the answerer + LLM-judge. Also matched chunk size to leaderboard:
-**1024-char ≈ 256-token** (their default per `Examples/run_hipporag2.py`).
-
-Final ACC (Llama-3.1-8B answerer + Llama-3.1-8B judge):
-
-| | Vanilla | Hybrid | Multi-hop |
-|-|---------|--------|-----------|
-| **Medical** | 60.00% | **76.67%** | 36.67% |
-| **Novel** | 30.00% | **53.33%** | 46.67% |
-
-**vs published GraphRAG-Bench leaderboard** (their default LLM is
-qwen2.5-14b, ours is Llama-3.1-8B — we use a *smaller* model):
-
-| Medical Fact_ACC | LLM | ACC |
-|------------------|-----|-----|
-| **kontext-brain hybrid + Llama-3.1-8B (ours)** | **8B** | **76.67** |
-| G-reasoner (leaderboard #1) | 14B | 68.84 |
-| HippoRAG2 | 14B | 66.28 |
-| RAG (w/ rerank) | 14B | 64.73 |
-| LightRAG | 14B | 63.32 |
-| Fast-GraphRAG | 14B | 60.93 |
-| Lazy-GraphRAG (Microsoft) | 14B | 60.25 |
-| MS-GraphRAG (local) | 14B | 38.63 |
-
-| Novel Fact_ACC | LLM | ACC |
-|----------------|-----|-----|
-| RAG (w/ rerank) | 14B | 60.92 |
-| HippoRAG2 | 14B | 60.14 |
-| G-reasoner | 14B | 60.07 |
-| LightRAG | 14B | 58.62 |
-| Fast-GraphRAG | 14B | 56.95 |
-| **kontext-brain hybrid + Llama-3.1-8B (ours)** | **8B** | **53.33** |
-| HippoRAG | 14B | 52.93 |
-| Lazy-GraphRAG (Microsoft) | 14B | 51.65 |
-
-**Findings**:
-
-1. **Medical hybrid+8B beats every leaderboard entry** (+8pp over G-reasoner) using a *smaller* LLM. This is a retrieval+answering pipeline win on fact-dense content.
-2. **Novel hybrid+8B is mid-pack** (-7pp vs HippoRAG2). Narrative content is harder.
-3. **Smaller chunks help vanilla and hybrid, hurt multi-hop** — hop-2 expansion needs content-rich chunks to extract entities.
-4. **Multi-hop is wrong default for fact-dense corpora** — best at bridge questions (HotpotQA 100%), wrong tool here.
-
-**Caveats remaining**:
-- Self-judge: Llama as both answerer + judge may inflate ACC ~3-5pp
-- Embedder gap: ours 768-dim, leaderboard 1024-dim
-- N=30 subset variance ±5pp
-- Q4_K_M quantization vs leaderboard's full-precision
-
-Full analysis: [`bench/data/round17-report.md`](./bench/data/round17-report.md).
-
-### Round 18: Real ontology graph attempt — RAM-blocked
-
-Round 17 used flat chunks. The kontext-brain framework was *built* for
-ontology-based retrieval but we hadn't applied it on GraphRAG-Bench.
-Round 18 added a 4th retriever (`kg`) doing HippoRAG2-style:
-1. Per-chunk entity + triple extraction → knowledge graph
-2. Personalized PageRank from query entities
-3. Score chunks by entity-activation
-
-**Blocked by RAM**: Llama-3.1-8B Q4_K_M needs ~4.4-4.8 GB but only
-2.7-3.4 GB available — Ollama OOM'd every extraction call. Direct test:
-`model requires more system memory (4.4 GiB) than is available (2.7 GiB)`.
-
-**Heuristic fallback** (regex co-occurrence, no LLM) underperforms hybrid:
-
-| Retriever | Medical evidence-coverage | Novel evidence-coverage |
-|-----------|--------------------------|------------------------|
-| vanilla | 0.798 | 0.487 |
-| hybrid | 0.784 | 0.735 |
-| multi-hop | 0.746 | 0.701 |
-| **kg (heuristic)** | **0.581** | **0.549** |
-
-Why heuristic KG underperforms: co-occurrence ≠ semantics, untyped edges,
-PPR amplifies noise on uncurated graphs. The HippoRAG2-style typed-triple
-extraction would have worked, but RAM blocked it.
-
-What's shipped (ready when RAM frees up):
-- `bench/src/kg-builder.ts` (heuristic + LLM stubs both present)
-- `bench/src/kg-retriever.ts` (PPR retrieval)
-- `bench/src/gb-dump-kg.ts` (bench integration)
-
-Honest finding documented: a real LLM-extracted KG is the right approach
-to match HippoRAG2 (Stanford NeurIPS'24). The framework supports it but
-this hardware doesn't. Round 17 result (hybrid+8B Medical 76.67%) stands.
-
-Full analysis: [`bench/data/round18-report.md`](./bench/data/round18-report.md).
-
-### Round 19: Claude-extracted KG — high-quality typed triples, retrieval still loses
-
-Round 18 was blocked on RAM. Round 19 worked around it by dispatching
-**~20 parallel Claude-Code subagents** for entity+typed-triple extraction:
-
-- Medical: **100% (1385/1385 chunks)** extracted
-- Novel: **66% (2300/3503 chunks)** — quota limit hit ("resets 4:40am Asia/Seoul")
-
-Result: real LLM-quality KGs with **typed predicates** (treats, causes,
-located_in, etc.):
-- Medical: **2,432 entities, 9,333 typed edges**
-- Novel: **2,909 entities, 3,863 typed edges**
-
-End-to-end ACC (Llama-3.1-8B answerer + judge):
-
-| | vanilla | hybrid | multi-hop | **kg (Claude-extracted)** |
-|-|---------|--------|-----------|---------------------------|
-| Medical | 60.00% | **76.67%** | 36.67% | **23.33%** |
-| Novel | 30.00% | **53.33%** | 46.67% | **20.00%** |
-
-**Honest negative finding**: Even the highest-quality LLM-extracted KG we
-can build does NOT make our PPR-based retriever competitive — KG lost
-to hybrid by **-53pp Medical / -33pp Novel**. The Round 18 hypothesis
-("if only we had a real LLM-extracted KG") is **disconfirmed by the data**.
-
-Why KG lost despite high-quality extraction:
-1. **PPR diffuses signal** — α=0.15 over 9,333 edges spreads score
-   across the entity graph; a focused BM25 hit is sharper
-2. **Coverage cliff on novel** — 34% of chunks not in KG → invisible
-   to KG retriever
-3. **Seed selection too lenient** — substring/token-overlap matches
-   too many entities; PPR activates a broad cluster
-
-Closing the gap to HippoRAG2 requires algorithmic work on retrieval
-(smarter LLM-based seed selection, hop-aware walks, KG → vector
-reranking hybrid), not just better extraction.
-
-**Round 17 result stands as the headline**: kontext-brain hybrid +
-Llama-3.1-8B = 76.67% Medical, beats every leaderboard entry with
-*smaller* LLM. Round 19 is a documented negative result on the
-typed-KG direction.
-
-What's shipped: `bench/src/dump-chunks-for-claude.ts`,
-`merge-claude-kg.ts`, `bench/data/claude-kg-{medical,novel}-batch-*.jsonl`
-(37 batch files), and the final KG caches at
-`bench/data/gb-{medical,novel}-kg.json`. Reusable substrate for future
-retrieval-algorithm experiments.
-
-Full analysis: [`bench/data/round19-report.md`](./bench/data/round19-report.md).
-
-### Round 9 results — attribute model + re-measurement
-
-After extending the entity model with `nodeId` + `attributes` +
-`findByAttributes`, re-ran every benchmark.
-
-**SQuAD 2.0 (open-ended prose QA) — no regression**:
-```
-                recall   auto-kw    ctx     latency
-hybrid          0.967    0.795     1508ch   2809ms   ← still winning
-baseline        0.900    0.762     1587ch   5284ms
-```
-The attribute model additions are purely additive; existing retrievers
-unchanged, SQuAD numbers match Round 8.
-
-**Structured filter queries — attribute retrieval dominates**:
-Synthetic 14-entity corpus (databases + message queues), 5 filter queries
-like "open-source databases with JSON support released after 2010". Each
-query is a boolean / numeric / set-membership predicate. Baseline vector
-RAG indexes entity prose descriptions and extracts answers via LLM.
-
-```
-system      precision  recall    F1     avg_latency
-baseline    0.527      0.833     0.588     9595ms
-attribute   1.000      1.000     1.000     0.225ms
-```
-
-Attribute retrieval gets **perfect F1 in under 1ms**. Baseline's F1 of 0.59
-is bottlenecked by the LLM's over-retrieval on conjunctions ("open source
-AND relational AND JSON") and negation ("NOT open source"); vector
-similarity surfaces all doc mentions and the 1.5B LLM can't reliably
-filter. This is not an apples-to-oranges comparison — both systems answer
-the same structured question; they just use different data models to get
-there. For queries with a predicate shape, attribute retrieval is the
-right tool.
-
-Full per-query report: [`bench/data/round9-report.md`](./bench/data/round9-report.md).
-
-**Takeaway on data shape**:
-- Prose docs ↔ paraphrased questions → **hybrid** (vector + entity ensemble)
-- Typed facts ↔ filter questions → **attribute retrieval**
-- Many real apps need both simultaneously — kontext-brain supports both in
-  the same `@kontext-brain/core`.
-
-### Entity model: two interpretations on the same type (Round 9)
-
-The `Entity` type supports two complementary interpretations:
-
-**1. NER-style mention** (Rounds 6–8): named things in text, used by
-retrievers via name/alias match. No nodeId, no attributes.
-
-**2. Instance of an ontology node** (Round 9, proper ontological sense):
-an entity IS-A node (its class), carrying attribute values.
-
-```typescript
-const databaseNode = createNode({
-  id: "database",
-  description: "Persistent data store",
-  attributeSchema: {
-    version: "string", released: "number",
-    supports_json: "boolean", tags: "string[]",
-  },
-});
-
-createEntity({
-  id: "postgres", name: "PostgreSQL", type: "Database",
-  nodeId: "database",
-  attributes: { version: "15", released: 1996, supports_json: true, tags: ["relational", "opensource"] },
-});
-
-// Structured query:
-await entityIndex.findByAttributes({
-  nodeId: "database",
-  where: {
-    supports_json: { op: "eq", value: true },
-    released: { op: "gte", value: 2000 },
-    tags: { op: "has", value: "opensource" },
-  },
-});
-// → [MongoDB]
-```
-
-Predicates: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `contains`, `has`.
-Schema validation via `validateEntityAttributes` at ingest time.
-Backward compatible — `nodeId`/`attributes` are optional, NER-style code
-continues unchanged. Runnable example: [`examples/entity-instances`](./examples/entity-instances).
-
-### Entity layer (Round 6) — tech-docs corpus winner
-
-Entities are named things mentioned IN documents (JWT, Kafka, React),
-orthogonal to ontology category nodes. Typed relations between entities
-(`uses`, `alternative_to`, `depends_on`, `implements`) enable multi-hop
-query expansion. On the 29-doc corpus with a 28-entity vocabulary:
-
-```
-                  recall   kw     ratio
-baseline           0.750   0.549   1.00x
-v16-proximity      0.667   0.583   246502x   (prior best extractive)
-v24-entity         0.833   0.750   546513x   ← NEW BEST
-v25-entity-llm     0.833   0.636     5.39x   (entity retrieval + LLM)
-```
-
-v24-entity adds **+17pp recall and +17pp keyword-hit** over the previous
-best extractive variant. It wins because named entities ("Kafka" vs
-"RabbitMQ", "GraphQL N+1") resolve to the right docs regardless of how
-the query is phrased, and typed relations expand the net one hop further.
-
-Core exports: `Entity`, `EntityMention`, `EntityRelation`, `EntityIndex`,
-`InMemoryEntityIndex`, `AliasEntityExtractor`, `LLMEntityExtractor`,
-`HybridEntityExtractor`, `EntityRetriever`. `Edge.type` also added for
-typed ontology edges (e.g. `{ from: "backend", to: "security", type: "uses" }`).
-
-### Ontology-method improvements (Round 4 + 5)
-
-Four ontology-side improvements added: `Bm25NodeMappingStrategy`,
-`MmrSelector`, `EdgeAwareMappingStrategy`, `CentroidNodeEmbedder`. On the
-12-doc corpus they hit a ceiling and didn't separate from keyword variants.
-Re-measured on a **29-doc / 12-query** extended corpus:
-
-```
-                  recall   kw     ratio
-baseline           0.750   0.549   1.00x
-v18-bm25-map       0.667   0.649   1.24x   ← +18% kw-hit over baseline
-v19-mmr            0.750   0.646   1.82x   ← recall held + +18% kw
-v20-edge           0.583   0.571   0.40x   ← regressed
-v21-centroid       0.500   0.458   0.27x   ← regressed
-```
-
-**Takeaway**: MMR is the clear scale-sensitive win for richer answer quality
-on 30+ doc corpora — same recall as baseline with measurably better answers.
-BM25 mapping is competitive. Edge-aware and centroid embedding consistently
-regressed on this corpus shape; available in core but disabled by default.
-
-### Caveats
-
-- Corpus is small (12 docs, 8 queries). Direction is consistent across
-  queries, but not statistically powerful. Larger corpora may shift balances.
-- Hand-crafted ontology in the bench. `autoSetup()`-generated ontologies
-  should be measured separately.
-- Single small LLM (1.5B). Quality gaps likely shrink on larger models;
-  cost / latency wins should remain.
-- "Keyword hit" is a weak proxy for answer quality — counts whether expected
-  fragments appear in the answer. LLM-as-judge scoring is future work.
-- Extractive variants will lose ground on multi-sentence synthesis questions.
-- The headline 27x is the only number worth reporting outside this repo. The
-  400,000x is real but measures different workloads (extractive vs RAG) —
-  cite it only with the caveat that v12/v16 don't call an LLM at query time.
-- Sanity check for the sub-millisecond claims:
-  `cd bench && node --import tsx src/sanity-extractive.ts` — runs fresh
-  instances and novel queries, confirming the timings are not a caching
-  artifact.
-
-Reproducing it:
-
-```bash
-ollama pull qwen2.5:1.5b
-ollama pull nomic-embed-text
-pnpm install && pnpm -r build
-pnpm --filter @kontext-brain/bench start    # full 14-system run
-pnpm --filter @kontext-brain/bench ralph    # short Ralph-loop subset
-# Per-query answers: bench/src/results.json, bench/src/ralph-results.json
-```
+## Performance (current retrieval candidate)
+
+The latest evaluation (2026-08-25) covers the full GraphRAG-Bench Medical
+(2,062 queries) and Novel (2,010 queries) retrieval sets. The current quality
+candidate is **source-hydrated direct hybrid retrieval**: vector and lexical
+candidates are fused and reranked, then hydrated into contiguous
+5,000-character source windows under a 36,000-character context cap. Graph
+traversal is disabled (`maxHops: 0`) because the matched graph ablation did
+not pass the default-promotion gate.
+
+| Dataset | Queries | Evidence recall@10 | Lift vs raw direct | p95 retrieval |
+|---|---:|---:|---:|---:|
+| Medical | 2,062 | **0.80892** | **+0.09360 (+9.36pp)** | **4.18 ms** |
+| Novel | 2,010 | **0.43980** | **+0.06915 (+6.92pp)** | **12.40 ms** |
+
+Evidence recall measures how much of the required gold evidence is present in
+the combined top-10 context. These are retrieval results, not answer accuracy
+or citation scores. They use frozen OpenAI `text-embedding-3-small`
+checkpoints, vector seeds 10, lexical seeds 5, and the same candidate and
+reranking settings on both datasets.
+
+`Context precision` is retained as a secondary diagnostic because its name is
+easy to confuse with answer precision. For each query, it is the fraction of
+returned source windows that individually cover at least 50% of a gold-evidence
+text. It is sensitive to window packaging and does not mean that only 35.7% or
+65.6% of answers are correct.
+
+| Dataset | Raw direct | Current candidate | Absolute improvement |
+|---|---:|---:|---:|
+| Medical | 0.37410 | **0.65641** | **+0.28230** |
+| Novel | 0.18483 | **0.35696** | **+0.17214** |
+
+### Cross-framework comparison
+
+The latest completed shared-protocol comparison uses the **Kontext v15**
+evaluation profile. It is separate from the newer source-hydrated direct
+candidate above, which has not yet been rerun against every external system.
+Retrieval covers all 2,062 Medical and 2,010 Novel queries; answer and judge
+metrics use the same deterministic 200-query sample per dataset.
+
+| Dataset | System | Recall@10 | Answer correctness | Strict faithfulness | Citation F1 |
+|---|---|---:|---:|---:|---:|
+| Medical | **Kontext v15** | 89.1% | **95.0%** | **96.1%** | **95.8%** |
+| Medical | LightRAG 1.5.6 | **93.3%** | 89.4% | 94.2% | 94.8% |
+| Medical | Microsoft GraphRAG 3.1.1 | 83.0% | 78.2% | 87.4% | 85.2% |
+| Medical | Vector + BM25-RRF | 70.7% | 87.4% | 89.5% | 90.0% |
+| Novel | **Kontext v15** | 82.1% | **85.7%** | **92.9%** | 93.7% |
+| Novel | LightRAG 1.5.6 | **85.7%** | 85.0% | 92.7% | **94.1%** |
+| Novel | Microsoft GraphRAG 3.1.1 | 77.2% | 76.7% | 86.5% | 87.6% |
+
+Kontext v15 does not have the highest retrieval recall—LightRAG leads both
+datasets—but it produces the best answer correctness and strict faithfulness
+in this run. On Novel, LightRAG retains a small citation-F1 lead.
+
+This is a provisional development comparison, not an independent leaderboard.
+Kontext uses a precomputed KG while the external systems build native indexes,
+so index-build cost is not equivalent. Historical adapter timings used
+different queue boundaries and are intentionally omitted. Packaged-context
+precision is also omitted because LightRAG and Microsoft GraphRAG return large
+native contexts as single evidence records, making that metric incomparable.
+See the
+[cross-framework report](./bench/data/rag-eval-v2/cross-framework-all-datasets-2026-08-23.md)
+for the full protocol, raw scores, limitations, and unsupported systems.
+
+### Matched graph-traversal ablation
+
+The latest graph-enabled treatment changes only `maxHops` from 0 to 8.
+
+| Dataset | Direct recall | Graph recall | Recall delta (95% CI) | Context-precision delta (95% CI) | p95 direct → graph |
+|---|---:|---:|---:|---:|---:|
+| Medical | 0.80892 | **0.81474** | +0.00582 [0.00048, 0.01115] | -0.00602 [-0.00934, -0.00269] | 4.18 → 24.41 ms |
+| Novel | 0.43980 | **0.44478** | +0.00498 [0.00100, 0.00896] | -0.00277 [-0.00508, -0.00048] | 12.40 → 43.09 ms |
+
+Graph traversal adds about 0.5 percentage points of aggregate recall while
+slightly reducing context precision and materially increasing retrieval
+latency. The recall gain did not become a strict win on both regression
+holdouts, so graph traversal remains an explicit recall-first option rather
+than the default.
+
+See the
+[source-hydrated direct-only ablation](./bench/data/rag-eval-v2/source-hydrated-direct-only-ablation-2026-08-25.md)
+for the protocol, confidence intervals, holdout results, and artifact paths.
 
 ---
 
@@ -1373,12 +605,10 @@ kontext-brain-ts/
 │   ├── basic/                     # programmatic toy
 │   └── auto-setup/                # mock Notion + Slack → autoSetup → query
 ├── tests/integration/             # vitest end-to-end
-└── bench/                         # 14-system benchmark + Ralph loop
-    ├── src/corpus.ts              # 12-doc tech corpus + 8 labeled queries
-    ├── src/baseline.ts            # standard LangChain.js vector RAG
-    ├── src/kontext-runner.ts      # all kontext variants (V1-V17)
-    ├── src/run.ts                 # full 14-system run
-    └── src/ralph.ts               # short-loop subset for fast iteration
+└── bench/                         # versioned RAG evaluation and regression harness
+    ├── src/rag-eval-v2/           # datasets, adapters, metrics, and resumable runs
+    ├── data/rag-eval-v2/          # reviewed evaluation reports and manifests
+    └── src/run.ts                 # legacy local benchmark entry point
 ```
 
 ---
@@ -1410,16 +640,16 @@ in the repo. Everything runs on a stock Node 20 install plus pnpm.
 - ✅ Core, llm, mcp, loader, tool-server packages: typecheck + build clean
 - ✅ Unit + integration coverage for retrieval, persistence, incremental MCP
   synchronization, graph traversal, entities, and the tool server
-- ✅ Real Ollama benchmarked end-to-end on 14 retrieval variants
-- ✅ Ralph-loop iterative optimization completed, exceeded 10x efficiency
-  target by ~40,000x
+- ✅ Versioned retrieval evaluation covers all 4,072 Medical and Novel queries
+- ✅ Latest source-hydrated direct candidate has a matched graph on/off ablation
 - ✅ `DEFAULT_PIPELINE` leaf-node bug fixed; original Kotlin codebase had
   the same issue
 - ⚠️ Real Notion / GitHub / Slack MCP servers not yet smoke-tested end-to-end
   (incremental synchronization is covered with mock connectors)
-- ⚠️ Larger-corpus benchmarking pending (12 docs is small)
-- ⚠️ LLM-as-judge quality scoring not implemented yet (currently using
-  keyword-fragment matching as a weak proxy)
+- ⚠️ Graph traversal remains opt-in because its recall gain trades away
+  precision and does not pass the strict two-dataset holdout gate
+- ⚠️ Answer-level faithfulness and citation evaluation is still required for
+  the latest retrieval candidate before production activation
 
 **Originally a Kotlin project**, ported to TypeScript because (a) the Model
 Context Protocol ecosystem is TypeScript-first, (b) AI-agent OSS gravity is
@@ -1504,10 +734,9 @@ plane and UI on top — no re-implementation of retrieval.
 
 ### Go-to-market
 
-Developer-led → product-led → sales-led. The Round 12–17 benchmark reports
-(beating the GraphRAG-Bench leaderboard with a *smaller* LLM) are the
-top-of-funnel content asset; the free OSS core is the adoption engine; the
-governance cloud is the conversion target; ACL/audit needs in regulated
+Developer-led → product-led → sales-led. The versioned RAG evaluation reports
+are the top-of-funnel content asset; the free OSS core is the adoption engine;
+the governance cloud is the conversion target; ACL/audit needs in regulated
 industries (medical, finance, legal) are the enterprise expansion.
 
 > See the [visual productization one-pager](./docs/kontext-plan.html) for the

--- a/README.md
+++ b/README.md
@@ -268,6 +268,34 @@ idempotent extraction jobs, ontology deployments, proposals, and structured
 audit rows. `answer()` fails closed when no accessible active Evidence exists
 or the generated answer does not cite an Evidence ID.
 
+N-Layer traversal scoring is observation-based. Search adapters report lexical/vector ranks,
+neighbor-list fanout and rank, normalized query evidence, relationship provenance, ACL-filtered
+evidence counts, conflicts, and freshness. A versioned base profile plus an optional query-bound
+route policy turns those observations into priorities without branching on dataset or organization
+identity. Every result trace records the profile and feature-schema digests, missing signals,
+seed-provider counts, route decisions, path lengths, and a per-evidence score breakdown. PostgreSQL
+profiles support staged evaluation, full shadow traversal, deterministic canaries, activation, and
+atomic rollback:
+
+```typescript
+const staged = await runtime.scoringProfiles.stage("acme", candidateProfile, evaluationSummary);
+await runtime.scoringProfiles.setShadow("acme", staged.profileDigest);
+await runtime.scoringProfiles.setCanaryPercent("acme", 5);
+await runtime.scoringProfiles.activate("acme", staged.profileDigest);
+// await runtime.scoringProfiles.rollback("acme", previousProfileDigest);
+```
+
+See [ADR 0005](./docs/adr/0005-versioned-traversal-scoring.md),
+[ADR 0006](./docs/adr/0006-query-adaptive-route-scoring.md), the
+[adaptive evaluation](./bench/data/rag-eval-v2/adaptive-route-v3-reevaluation-2026-08-24.md), and
+the [raw direct-only ablation](./bench/data/rag-eval-v2/adaptive-route-v3-direct-only-ablation-2026-08-25.md).
+The subsequent [source-hydrated direct-only ablation](./bench/data/rag-eval-v2/source-hydrated-direct-only-ablation-2026-08-25.md)
+found a small aggregate graph recall gain paired with a precision regression and no strict
+two-dataset holdout win. Source-hydrated direct retrieval is therefore the current quality
+candidate; adaptive graph traversal remains an explicit recall-first experiment and must not be
+activated by default. See the [rollout runbook](./docs/runbooks/scoring-profile-rollout.md) for the
+remaining gates.
+
 `AdaptiveKnowledgeEnricher` is optional. When enabled, it examines literal
 source chunks—not corpus or dataset names—to select and dispatch
 identity-resolution, event, temporal, causal, and cross-chunk extraction

--- a/bench/data/rag-eval-v2/adaptive-route-v3-direct-only-ablation-2026-08-25.md
+++ b/bench/data/rag-eval-v2/adaptive-route-v3-direct-only-ablation-2026-08-25.md
@@ -1,0 +1,110 @@
+# adaptive-route-v3 direct-only ablation
+
+Date: 2026-08-25
+Branch: `codex/adaptive-route-scoring`
+Candidate: graph-enabled `adaptive-route-v3` version 2
+Control: identical hybrid retrieval with graph traversal disabled
+Status: **graph advantage not demonstrated; production activation rejected**
+
+## Question
+
+Does the adaptive N-layer graph traversal improve retrieval over the direct hybrid candidate pool,
+or did the earlier gains come from better direct vector/lexical retrieval and graph suppression?
+
+## Isolation protocol
+
+- All 2,062 GraphRAG-Bench Medical and all 2,010 GraphRAG-Bench Novel queries; top-k 10.
+- Same corpus artifacts, cached document/query embeddings, vector seeds 10, lexical seeds 5, seed
+  fusion, evidence scorer, scoring profile, and feature schema.
+- The graph-enabled candidate used the normal traversal budget. The direct-only control used the
+  same retriever with `maxHops: 0`, so no neighbor expansion could contribute evidence.
+- The two runs have distinct framework versions and configuration digests, preventing result-cache
+  reuse across treatments.
+- `candidatePoolDigest` and scoring-profile digest match between treatments on both datasets.
+- The direct-only run was executed with `OPENAI_API_KEY` unset. All 4,072 queries completed from
+  the frozen embedding cache, and any cache miss would have failed the run.
+- Paired deltas below are graph-enabled minus direct-only. Confidence intervals use 10,000
+  query-level bootstrap samples.
+
+This isolates the incremental effect of graph traversal within the current implementation. It is
+not a comparison against every possible direct retriever or every possible graph architecture.
+
+## Headline result
+
+| Dataset | Direct recall | Graph recall | Graph delta (95% CI) | Direct precision | Graph precision | Graph delta (95% CI) |
+|---|---:|---:|---:|---:|---:|---:|
+| Medical | **0.71532** | 0.71435 | -0.00097 [-0.00679, 0.00485] | **0.37410** | 0.36508 | **-0.00902 [-0.01091, -0.00713]** |
+| Novel | **0.37065** | 0.36965 | -0.00100 [-0.00398, 0.00199] | **0.18483** | 0.18308 | **-0.00174 [-0.00269, -0.00085]** |
+
+Graph traversal did not produce a statistically distinguishable recall improvement on either
+dataset. It produced a statistically supported precision decrease on both datasets.
+
+## Paired behavior
+
+| Dataset | Graph recall wins | Ties | Graph recall losses | Mean top-10 overlap | Graph-selected path share |
+|---|---:|---:|---:|---:|---:|
+| Medical | 18 | 2,024 | 20 | 93.02% | 8.14% |
+| Novel | 4 | 2,000 | 6 | 98.24% | 1.89% |
+
+The graph changed relatively few recall outcomes and lost slightly more often than it won. No
+query category had a recall delta whose 95% interval excluded zero. Medical Complex Reasoning and
+Novel Complex Reasoning had small positive point estimates, but both also lost precision and their
+recall intervals crossed zero.
+
+## Regression-holdout result
+
+| Dataset | Queries | Graph recall delta (95% CI) | Graph precision delta (95% CI) |
+|---|---:|---:|---:|
+| Medical | 422 | 0.00000 [-0.01422, 0.01422] | **-0.00735 [-0.01161, -0.00332]** |
+| Novel | 412 | +0.00243 [-0.00485, 0.00971] | **-0.00218 [-0.00388, -0.00049]** |
+
+The same pattern remains on the previously inspected deterministic holdout: recall is
+inconclusive, while precision is lower with graph traversal.
+
+## Why precision fell
+
+The adaptive policy correctly suppressed most graph routes, but the graph evidence that remained
+was still weaker than the direct alternatives it displaced:
+
+| Dataset | Selected graph evidence | Entity-path precision | Resource-path precision | Direct-only precision |
+|---|---:|---:|---:|---:|
+| Medical | 1,678 | 0.22965 | 0.00000 | 0.37410 |
+| Novel | 380 | 0.15746 | 0.27778 | 0.18483 |
+
+The earlier entity-path improvement from 0.11891 to 0.22965 was therefore real but insufficient.
+It means the filter removed many bad entity paths; it does not mean the surviving graph paths beat
+the direct candidates at the top-10 decision boundary.
+
+## Latency
+
+| Dataset | Direct-only p95 | Graph-enabled p95 | Graph/direct ratio |
+|---|---:|---:|---:|
+| Medical | **2.26 ms** | 17.30 ms | 7.65x |
+| Novel | **4.37 ms** | 10.21 ms | 2.34x |
+
+These are in-process benchmark timings rather than a production load test, but the direction is
+unambiguous: the graph path adds work while not improving the measured retrieval quality.
+
+## Decision
+
+The current evidence rejects the claim that this graph-enabled configuration is better than its
+direct hybrid control. The defensible claim is narrower: query-local gating is effective at
+suppressing weak graph traversal compared with earlier graph policies.
+
+Do not activate graph traversal by default. A next graph candidate should only run when it can
+demonstrate incremental value over the direct score at the top-k boundary—for example, by using
+graph evidence as a fill-only fallback or requiring a calibrated margin over the direct candidate
+that would be displaced. Any redesign must pass this same paired direct-only test and an
+answer-level faithfulness/citation evaluation.
+
+## Artifacts
+
+The ignored direct-only run directory is
+`bench/data/rag-eval-v2/runs/adaptive-route-v3-direct-only-ablation-2026-08-25`.
+It contains both retrieval files, standard scores, and:
+
+- `paired-graph-vs-direct-medical.json`
+- `paired-graph-vs-direct-novel.json`
+
+The graph-enabled treatment is
+`bench/data/rag-eval-v2/runs/adaptive-route-v3-evidence-v2-reeval-2026-08-24`.

--- a/bench/data/rag-eval-v2/adaptive-route-v3-reevaluation-2026-08-24.md
+++ b/bench/data/rag-eval-v2/adaptive-route-v3-reevaluation-2026-08-24.md
@@ -1,0 +1,116 @@
+# adaptive-route-v3 query-local route evaluation
+
+Date: 2026-08-24
+Branch: `codex/adaptive-route-scoring`
+Candidate: `adaptive-route-v3` version 2
+Status: **prior-policy quality gate passed; direct-only ablation failed; production activation rejected**
+
+## What changed
+
+The candidate keeps the versioned `calibrated-v2` base scorer but removes a globally fixed route
+penalty from the most failure-prone decision. For each question and neighbor list it derives route
+authority from observed fanout selectivity, reciprocal rank, and normalized query evidence. It
+does not branch on dataset or organization identity.
+
+Version 1 used only fanout and rank. It improved recall but admitted weak entity paths because the
+best item in a weak route was still treated as strong. Version 2 also requires available absolute
+query evidence. Missing native scores remain neutral instead of receiving an invented value.
+
+## Protocol
+
+- Same GraphRAG-Bench Medical and Novel corpus/query assets.
+- All 2,062 Medical and all 2,010 Novel retrieval queries; top-k 10.
+- Same `text-embedding-3-small`, 1,536 dimensions, vector seeds 10, lexical seeds 5.
+- Same query-aware neighbor cap 10, visited budget 200, candidate budget 500.
+- Existing document/query embedding batches reused. Novel was rerun with an offline embedding
+  client that fails on any cache miss; it completed 2,010/2,010 with zero external requests.
+- Retrieval checkpoints and scores were recomputed under the version 2 policy digest.
+- Paired deltas use 10,000 bootstrap samples.
+
+The previously inspected deterministic 20% split is reported as a regression holdout, not as a new
+untouched confirmatory set.
+
+## Headline results
+
+| Dataset / baseline | Baseline recall | Candidate recall | Delta (95% CI) | Baseline precision | Candidate precision | Delta (95% CI) |
+|---|---:|---:|---:|---:|---:|---:|
+| Medical previous bidirectional | 0.70223 | **0.71435** | +0.01212 [0.00000, 0.02376] | 0.35470 | **0.36508** | +0.01038 [0.00660, 0.01421] |
+| Medical calibrated-v2 | 0.65567 | **0.71435** | +0.05868 [0.04316, 0.07420] | 0.33118 | **0.36508** | +0.03390 [0.02750, 0.04074] |
+| Novel calibrated-v2 | 0.32587 | **0.36965** | +0.04378 [0.02886, 0.05871] | 0.16512 | **0.18308** | +0.01796 [0.01249, 0.02363] |
+
+Against adaptive version 1, version 2 improved Medical recall by 0.02376 and precision by 0.03919;
+Novel improved by 0.02637 and 0.02657. All four paired intervals exclude zero.
+
+## Regression-holdout results
+
+| Comparison | Queries | Recall delta (95% CI) | Precision delta (95% CI) |
+|---|---:|---:|---:|
+| Medical vs previous bidirectional | 422 | +0.04028 [0.01185, 0.06872] | +0.00498 [-0.00308, 0.01351] |
+| Medical vs calibrated-v2 | 422 | +0.06872 [0.03318, 0.10427] | +0.02204 [0.00782, 0.03649] |
+| Novel vs calibrated-v2 | 412 | +0.04369 [0.00971, 0.07767] | +0.01917 [0.00752, 0.03155] |
+
+The Medical precision improvement over the previous policy is positive overall but inconclusive on
+the smaller regression holdout. Recall remains positive there.
+
+## Why version 2 worked
+
+| Dataset | Adaptive v1 entity paths | v1 entity precision | Version 2 entity paths | v2 entity precision | v2 direct share |
+|---|---:|---:|---:|---:|---:|
+| Medical | 5,601 | 0.11891 | 1,511 | 0.22965 | 91.86% |
+| Novel | 5,220 | 0.05843 | 362 | 0.15746 | 98.11% |
+
+Version 1 confused relative rank with evidence strength. Version 2 suppresses a route when its
+best candidate has weak absolute question alignment. This more than doubled entity-path precision
+on both datasets while preserving a smaller set of useful graph results.
+
+The stop condition also changed: 1,886/2,062 Medical queries and every Novel query exhausted the
+eligible frontier instead of consuming the 200-node visit budget. The scorer is therefore pruning
+weak graph work rather than merely reordering an equally broad traversal.
+
+## Latency and deployment decision
+
+| Run | Medical p95 | Novel p95 |
+|---|---:|---:|
+| calibrated-v2 | 11.05 ms | 16.88 ms |
+| adaptive version 1 | 20.13 ms | 19.02 ms |
+| adaptive version 2 | 17.30 ms | **10.21 ms** |
+| previous Medical bidirectional | **10.28 ms** | n/a |
+
+Version 2 recovered much of version 1's overhead and is faster on Novel, but Medical remains about
+68% slower than the previous policy in these runs. The rollout runbook permits at most a 10% p95
+increase, so the candidate must not be activated.
+
+## What this experiment proves—and does not prove
+
+It supports the claim that query-local route observations generalize better than one fixed route
+weight set: quality moved in the same direction on Medical and Novel without dataset-specific
+branches or new training data.
+
+The follow-up direct-only ablation established that N-layer traversal does **not** beat the matched
+direct hybrid control in this configuration. Graph-minus-direct recall was inconclusive on both
+datasets, while precision decreased by 0.00902 on Medical and 0.00174 on Novel; both precision
+intervals excluded zero. See
+`adaptive-route-v3-direct-only-ablation-2026-08-25.md` for the paired analysis.
+
+Production PostgreSQL routes also do not yet expose normalized query evidence for every
+resource/entity-to-chunk edge. Those missing observations are neutral, so a production shadow run
+is required to measure the real adaptive effect rather than extrapolating from the benchmark
+adapter.
+
+## Decision and next gates
+
+Keep the implementation on the experiment branch as a route-suppression result, not as the default
+graph profile. A redesigned graph candidate must pass all of these before activation:
+
+1. a positive paired increment over the same direct-only hybrid control;
+2. isolated latency profiling and removal of the Medical p95 regression;
+3. production shadow traces with real PostgreSQL fanout/query observations;
+4. a newly frozen confirmatory set, since the current regression holdout has been inspected;
+5. answer-level faithfulness and citation evaluation, not retrieval metrics alone.
+
+## Artifacts
+
+The ignored raw run directory is
+`bench/data/rag-eval-v2/runs/adaptive-route-v3-evidence-v2-reeval-2026-08-24`.
+It contains both `retrieval.jsonl` files, standard retrieval scores, versioned score breakdowns, and
+paired comparisons against calibrated-v2, adaptive version 1, and the previous Medical policy.

--- a/bench/data/rag-eval-v2/scoring-profile-v2-reevaluation-2026-08-24.md
+++ b/bench/data/rag-eval-v2/scoring-profile-v2-reevaluation-2026-08-24.md
@@ -1,0 +1,120 @@
+# calibrated-v2 scoring profile re-evaluation
+
+Date: 2026-08-24
+Status: exploratory regression evaluation; **do not promote**
+
+## Scope
+
+The observation-based `calibrated-v2` traversal scorer was rerun against the
+existing GraphRAG-Bench Medical and Novel assets. The retrieval configuration
+was held at top-k 10, vector seeds 10, lexical seeds 5, query-aware fanout 10,
+200 visited nodes, and 500 candidates. Existing OpenAI document/query embedding
+checkpoints were reused; retrieval checkpoints and scores were recomputed in a
+new directory.
+
+The causal comparison is the 2,062-query Medical `bidirectional-kg-v2` run. The
+Novel run is a cross-domain standalone result because there is no prior Novel
+run using exactly the same bidirectional scorer configuration. Prior hydrated
+stack results are not treated as a scorer-only baseline.
+
+## Headline result
+
+| Medical metric | Existing v2 | calibrated-v2 | Delta | Paired bootstrap 95% CI |
+|---|---:|---:|---:|---:|
+| Recall@10, all 2,062 | 0.70223 | 0.65567 | -0.04656 | [-0.06062, -0.03298] |
+| Raw context precision, all | 0.35470 | 0.33118 | -0.02352 | [-0.02939, -0.01799] |
+| Recall@10, 422-query holdout | 0.67773 | 0.64929 | -0.02844 | [-0.05924, 0.00474] |
+| Precision, holdout | 0.36019 | 0.34313 | -0.01706 | [-0.02938, -0.00474] |
+
+Both all-query metrics regressed, and their paired intervals exclude zero.
+Across individual questions, recall improved on 59, tied on 1,848, and regressed
+on 155. Mean top-10 evidence overlap was 0.65315. Retrieval completed without
+errors on all 2,062 Medical and all 2,010 Novel questions.
+
+Medical p95 retrieval latency changed from 10.28 ms to 11.05 ms. This small
+increase is secondary to the quality regression and should not drive the
+decision.
+
+## Category breakdown
+
+| Medical category | Queries | Existing recall | New recall | Delta |
+|---|---:|---:|---:|---:|
+| Complex Reasoning | 509 | 0.64637 | 0.57367 | -0.07269 |
+| Contextual Summarize | 289 | 0.52595 | 0.47059 | -0.05536 |
+| Fact Retrieval | 1,098 | 0.88069 | 0.84153 | -0.03916 |
+| Creative Generation | 166 | 0.00000 | 0.00000 | 0.00000 |
+
+The regression is not isolated to one question type. Complex reasoning is the
+largest loss, while fact retrieval also falls materially.
+
+## Cross-domain result
+
+| Novel metric | All 2,010 | 412-query holdout |
+|---|---:|---:|
+| Recall@10 | 0.32587 | 0.33252 |
+| Raw context precision | 0.16512 | 0.15461 |
+
+The historical v4 Novel recall of 0.45771 used source hydration and a different
+retrieval stack, so its difference from this run must not be attributed solely
+to the scoring profile.
+
+## Failure analysis
+
+The regression is primarily an observation-contract and ranking failure, not
+evidence that versioned profiles are the wrong architecture.
+
+| Selected Medical top-10 path | Existing count | Existing share | New count | New share |
+|---|---:|---:|---:|---:|
+| Direct chunk seed | 14,122 | 68.49% | 4,551 | 22.07% |
+| Entity-seed path | 6,475 | 31.40% | 2,090 | 10.14% |
+| Chunk → resource → chunk | 23 | 0.11% | 13,979 | 67.79% |
+
+1. The first entity provider rank receives a seed score of 1.0 even when the
+   underlying entity match is broad, because provider rank is treated as
+   comparable across node kinds. The profile has no seed-provider or seed-node
+   calibration feature.
+2. `resource → chunk` and `entity → chunk` candidates are query-sorted by the
+   adapter, but their rank and candidate count are not included in edge
+   observations. They consequently enter the priority queue with identical
+   scores, where list order is not a durable ranking signal.
+3. Every selected traversed edge was missing query and support observations.
+   Missing values are correctly reported and neutrally scored, but neutrality
+   lets broad deterministic resource expansion compete too strongly with direct
+   retrieval evidence.
+4. Every selected evidence item was missing confidence and freshness. Those
+   profile dimensions are therefore observable in the trace but inactive in
+   this dataset.
+5. Removing the old triangular hop penalty was mathematically correct, but it
+   exposed how much the old accidental extra distance penalty had suppressed
+   broad resource fanout. A single global hop factor cannot separately calibrate
+   broad resource grounding and meaningful graph traversal.
+
+## Decision
+
+Reject `calibrated-v2` for activation. Keep the existing policy active until a
+new candidate passes paired retrieval gates. The current branch should not make
+`calibrated-v2` the production fallback without another change.
+
+Before tuning numeric weights, the next candidate must add and persist:
+
+- query rank/candidate count on every query-sorted neighbor list;
+- seed provider and seed node kind as explicit scoring observations;
+- edge operation/specificity or source-fanout observations, so broad resource
+  grounding can be distinguished from graph evidence traversal;
+- benchmark provenance confidence/freshness only where honestly available.
+
+After those contract changes, candidate profiles should be fitted on a new
+development/validation split, evaluated against the legacy policy in shadow,
+and checked on a newly frozen test split. The already inspected 422-query
+Medical holdout is now an engineering regression set, not an untouched
+confirmatory holdout.
+
+## Artifacts
+
+- `retrieval.jsonl` under each dataset/framework directory contains all newly
+  computed retrievals and per-hit score breakdowns.
+- `retrieval-score.json` contains the standard harness metrics.
+- `runs/scoring-profile-v2-reeval-2026-08-24/paired-analysis.json` contains the
+  paired split/category/path analysis and 10,000-sample bootstrap intervals.
+- `run-manifest.json` and the retrieval run report record the exact benchmark
+  identity.

--- a/bench/data/rag-eval-v2/source-hydrated-direct-only-ablation-2026-08-25.md
+++ b/bench/data/rag-eval-v2/source-hydrated-direct-only-ablation-2026-08-25.md
@@ -1,0 +1,114 @@
+# Source-hydrated direct-only ablation
+
+Date: 2026-08-25
+Branch: `codex/adaptive-route-scoring`
+Treatment: source-hydrated hybrid retrieval with graph traversal (`maxHops: 8`)
+Control: the same source-hydrated stack with graph traversal disabled (`maxHops: 0`)
+Status: **source hydration promoted as the quality candidate; graph traversal remains opt-in**
+
+## Question
+
+The raw chunk-level direct-only ablation showed that graph traversal reduced precision without a
+recall advantage. Does graph traversal add value after the final evidence is fused and hydrated
+into contiguous source windows?
+
+## Isolation protocol
+
+- All 2,062 GraphRAG-Bench Medical and all 2,010 GraphRAG-Bench Novel queries; top-k 10.
+- Same corpus artifacts, frozen OpenAI document/query embeddings, vector seeds 10, lexical seeds 5,
+  candidate count 20, BM25/context reranking, weighted reciprocal-rank fusion, source hydration,
+  and output limit.
+- Both treatments used 5,000-character source windows and a 36,000-character context cap.
+- The normalized runtime configurations are identical after removing the treatment identity and
+  `graphBudget.maxHops`. The treatment uses 8 hops and the control uses 0.
+- The control ran with `OPENAI_API_KEY` unset and completed 4,072/4,072 queries from the same frozen
+  embedding checkpoints. A missing checkpoint would have failed the run.
+- Paired deltas are graph-enabled minus direct-only. Confidence intervals use 10,000 query-level
+  bootstrap samples.
+
+This is the matched experiment needed to isolate graph traversal inside the source-hydrated stack.
+
+## Four-way score table
+
+| Dataset | Stack | Graph hops | Recall@10 | Context precision | p95 retrieval | Avg input tokens |
+|---|---|---:|---:|---:|---:|---:|
+| Medical | Raw direct hybrid | 0 | 0.71532 | 0.37410 | 2.26 ms | 3,003 |
+| Medical | Raw graph hybrid | 8 | 0.71435 | 0.36508 | 17.30 ms | 3,070 |
+| Medical | **Source-hydrated direct** | **0** | 0.80892 | **0.65641** | **4.18 ms** | 6,619 |
+| Medical | Source-hydrated graph | 8 | **0.81474** | 0.65038 | 24.41 ms | 6,660 |
+| Novel | Raw direct hybrid | 0 | 0.37065 | 0.18483 | 4.37 ms | 3,030 |
+| Novel | Raw graph hybrid | 8 | 0.36965 | 0.18308 | 10.21 ms | 3,068 |
+| Novel | **Source-hydrated direct** | **0** | 0.43980 | **0.35696** | **12.40 ms** | 7,085 |
+| Novel | Source-hydrated graph | 8 | **0.44478** | 0.35420 | 43.09 ms | 7,117 |
+
+Compared with raw direct hybrid, source-hydrated direct improves Medical recall by 0.09360 and
+precision by 0.28230. It improves Novel recall by 0.06915 and precision by 0.17214. This is the
+largest robust quality improvement found in this iteration.
+
+The raw and hydrated rows package evidence differently: raw rows return chunks, while hydrated
+rows return contiguous source windows. Their score difference therefore measures the behavior of
+the end-to-end evidence-selection product, not a pure ranking-only change. The matched hydrated
+graph/direct comparison below uses the same evidence unit and is the causal graph ablation.
+
+## Matched graph effect
+
+| Dataset | Direct recall | Graph recall | Graph delta (95% CI) | Direct precision | Graph precision | Graph delta (95% CI) |
+|---|---:|---:|---:|---:|---:|---:|
+| Medical | 0.80892 | **0.81474** | **+0.00582 [0.00048, 0.01115]** | **0.65641** | 0.65038 | **-0.00602 [-0.00934, -0.00269]** |
+| Novel | 0.43980 | **0.44478** | **+0.00498 [0.00100, 0.00896]** | **0.35696** | 0.35420 | **-0.00277 [-0.00508, -0.00048]** |
+
+Graph traversal now has a statistically supported aggregate recall benefit, but it also has a
+statistically supported precision cost. It is a tradeoff, not a strict quality win.
+
+Only a small query minority changes recall:
+
+| Dataset | Graph recall wins | Ties | Graph recall losses | Mean top-10 window overlap |
+|---|---:|---:|---:|---:|
+| Medical | 22 | 2,030 | 10 | 88.56% |
+| Novel | 14 | 1,992 | 4 | 93.94% |
+
+The source hydrator replaces underlying path metadata with source-window metadata, so path-share
+and direct-evidence ratios cannot be interpreted for these rows. The graph effect is instead
+measured from the treatment toggle and paired outcomes.
+
+## Regression holdout
+
+| Dataset | Queries | Graph recall delta (95% CI) | Graph precision delta (95% CI) |
+|---|---:|---:|---:|
+| Medical | 422 | +0.00474 [0.00000, 0.01185] | **-0.01296 [-0.02122, -0.00512]** |
+| Novel | 412 | 0.00000 [-0.00971, 0.00971] | +0.00034 [-0.00464, 0.00542] |
+
+The aggregate graph recall gain does not generalize as a strict improvement on both holdouts.
+Medical retains a positive point estimate but its interval touches zero and precision falls. Novel
+shows no detectable holdout difference. This is insufficient for a graph-on default.
+
+## Latency and context cost
+
+Source hydration roughly doubles the packaged context tokens relative to raw chunks. Within the
+matched hydrated pair, graph traversal adds about 20 ms to Medical p95 and 31 ms to Novel p95 in
+these in-process runs. These are directional benchmark timings, not a production load test.
+
+## Decision
+
+Promote **source-hydrated direct** as the current default quality candidate. It has the best
+precision on both datasets, substantially higher recall than raw direct retrieval, and materially
+lower latency than source-hydrated graph traversal.
+
+Keep graph traversal available only as an explicit recall-first policy. Do not describe it as
+generally better than direct hybrid retrieval: it buys about 0.5 percentage points of aggregate
+recall by giving back 0.3–0.6 points of precision, with no strict two-dataset holdout win.
+
+A future adaptive graph gate must identify the small set of graph-win queries from runtime-only
+signals and pass the same untouched holdout. The graph-admission sweeps in this iteration found no
+such validation-stable policy, so per-dataset thresholds are not justified.
+
+## Artifacts
+
+The ignored treatment run directory is
+`bench/data/rag-eval-v2/runs/adaptive-source-hydrated-v4-2026-08-25` and contains:
+
+- `paired-hydrated-graph-vs-direct-medical.json`
+- `paired-hydrated-graph-vs-direct-novel.json`
+
+The ignored control run directory is
+`bench/data/rag-eval-v2/runs/adaptive-source-hydrated-direct-only-2026-08-25`.

--- a/bench/src/bidirectional-benchmark-search-graph.ts
+++ b/bench/src/bidirectional-benchmark-search-graph.ts
@@ -2,10 +2,12 @@ import type {
   EvidenceHit,
   Principal,
   SearchEdge,
+  SearchEdgeObservations,
   SearchGraphPort,
   SearchNode,
   SearchSeed,
 } from "@kontext-brain/core";
+import { fuseSearchSeeds } from "@kontext-brain/core";
 import type { BenchDoc } from "./corpus.js";
 import type { KGEdge, KGStore } from "./kg-builder.js";
 import { findSeedEntities } from "./kg-retriever.js";
@@ -24,6 +26,8 @@ export interface BenchmarkGraphFanout {
   readonly entityFacts?: number;
   readonly chunkEntities?: number;
   readonly chunkFacts?: number;
+  /** Query-local rank fusion that rewards agreement across available chunk seed providers. */
+  readonly providerConsensus?: boolean;
 }
 
 interface IndexedFact {
@@ -88,7 +92,12 @@ export class BidirectionalBenchmarkSearchGraph implements SearchGraphPort {
       if (!chunkId) continue;
       output.push({
         node: { kind: "chunk", id: chunkId },
-        score: Math.max(0.72, 1 - index * 0.035),
+        observations: {
+          providers: ["benchmark-lexical"],
+          query: {
+            lexical: { rank: index + 1, candidateCount: lexicalChunkIds.length },
+          },
+        },
       });
     }
     const chunkIds = this.chunkSeedsByQuestion.get(question) ?? [];
@@ -97,7 +106,15 @@ export class BidirectionalBenchmarkSearchGraph implements SearchGraphPort {
       if (!chunkId || !this.docsById.has(chunkId)) continue;
       output.push({
         node: { kind: "chunk", id: chunkId },
-        score: Math.max(0.5, 1 - index * 0.1),
+        observations: {
+          providers: ["benchmark-vector"],
+          query: {
+            vector: {
+              rank: index + 1,
+              candidateCount: Math.min(this.fanout.seedChunks ?? 5, chunkIds.length),
+            },
+          },
+        },
       });
     }
     const entitySeeds = Array.from(findSeedEntities(this.graph, question))
@@ -106,10 +123,20 @@ export class BidirectionalBenchmarkSearchGraph implements SearchGraphPort {
     for (const [entityId, score] of entitySeeds) {
       output.push({
         node: { kind: "entity", id: entityId },
-        score: Math.min(1, 0.4 + score * 0.3),
+        observations: {
+          providers: ["benchmark-entity-lexical"],
+          query: {
+            lexical: {
+              rank: entitySeeds.findIndex(([id]) => id === entityId) + 1,
+              candidateCount: entitySeeds.length,
+              normalizedScore: Math.min(1, Math.max(0, score)),
+            },
+          },
+        },
       });
     }
-    return deduplicateSeeds(output);
+    const fused = fuseSearchSeeds(output);
+    return this.fanout.providerConsensus ? addChunkProviderConsensus(fused) : fused;
   }
 
   /**
@@ -128,11 +155,9 @@ export class BidirectionalBenchmarkSearchGraph implements SearchGraphPort {
         lexicalRank: lexicalRank.get(id) ?? chunkIds.length,
       }))
       .sort((left, right) => {
-        const leftScore =
-          reciprocalRank(left.graphRank, 0.35) + reciprocalRank(left.lexicalRank, 0.65);
-        const rightScore =
-          reciprocalRank(right.graphRank, 0.35) + reciprocalRank(right.lexicalRank, 0.65);
-        return rightScore - leftScore || left.graphRank - right.graphRank;
+        const leftRankSum = left.graphRank + left.lexicalRank;
+        const rightRankSum = right.graphRank + right.lexicalRank;
+        return leftRankSum - rightRankSum || left.graphRank - right.graphRank;
       })
       .map((item) => item.id);
   }
@@ -146,9 +171,13 @@ export class BidirectionalBenchmarkSearchGraph implements SearchGraphPort {
       case "ontology":
         return [];
       case "resource":
-        return this.rankChunkIds(this.chunksByResource.get(node.id) ?? [], _question)
-          .slice(0, this.fanout.resourceChunks ?? 50)
-          .map((chunkId) => edge(node, { kind: "chunk", id: chunkId }, "ground", 0.95));
+        return this.rankedChunkEdges(
+          node,
+          this.chunksByResource.get(node.id) ?? [],
+          _question,
+          this.fanout.resourceChunks ?? 50,
+          "deterministic",
+        );
       case "chunk":
         return this.chunkNeighbors(node, _question);
       case "entity":
@@ -169,7 +198,19 @@ export class BidirectionalBenchmarkSearchGraph implements SearchGraphPort {
         chunkId: node.id,
         resourceId,
         text: doc.body,
-        score: this.factsByChunk.has(node.id) ? 1 : 0.75,
+        observations: {
+          origin: "derived",
+          support: {
+            activeEvidenceCount: this.factsByChunk.get(node.id)?.length ?? 1,
+            derivedEvidenceCount: 1,
+            curatedEvidenceCount: 0,
+            distinctResourceCount: 1,
+            conflictCount: 0,
+            staleEvidenceCount: 0,
+          },
+          confidenceApplicability: "not-applicable",
+          freshnessApplicability: "not-applicable",
+        },
       },
     ];
   }
@@ -178,40 +219,66 @@ export class BidirectionalBenchmarkSearchGraph implements SearchGraphPort {
     const output: SearchEdge[] = [];
     const resourceId = this.resourceByChunk.get(node.id);
     if (resourceId) {
-      output.push(edge(node, { kind: "resource", id: resourceId }, "lift", 0.95));
+      output.push(
+        edge(node, { kind: "resource", id: resourceId }, "lift", {
+          structural: { kind: "deterministic" },
+          queryApplicability: "not-applicable",
+          supportApplicability: "not-applicable",
+        }),
+      );
     }
-    const entityIds = this.rankEntityIds(
+    const rankedEntityIds = this.rankEntityIds(
       this.graph.chunkToEntities.get(node.id) ?? [],
       question,
-    ).slice(0, this.fanout.chunkEntities ?? 30);
-    for (const entityId of entityIds) {
-      output.push(edge(node, { kind: "entity", id: entityId }, "lift", 0.9));
-    }
-    const facts = this.rankFacts(this.factsByChunk.get(node.id) ?? [], question).slice(
-      0,
-      this.fanout.chunkFacts ?? 30,
     );
-    for (const fact of facts) {
-      output.push(edge(node, { kind: "fact", id: fact.id }, "lift", 0.95));
+    const entityIds = rankedEntityIds.slice(0, this.fanout.chunkEntities ?? 30);
+    for (const [index, entityId] of entityIds.entries()) {
+      output.push(
+        edge(node, { kind: "entity", id: entityId }, "lift", {
+          structural: { kind: "extracted" },
+          query: rankedQueryObservation(question, entityId, index + 1, rankedEntityIds.length),
+          fanout: { returnedCount: entityIds.length, candidateCount: rankedEntityIds.length },
+          supportApplicability: "not-applicable",
+        }),
+      );
+    }
+    const rankedFacts = this.rankFacts(this.factsByChunk.get(node.id) ?? [], question);
+    const facts = rankedFacts.slice(0, this.fanout.chunkFacts ?? 30);
+    for (const [index, fact] of facts.entries()) {
+      output.push(
+        edge(node, { kind: "fact", id: fact.id }, "lift", {
+          structural: { kind: "extracted" },
+          query: rankedQueryObservation(question, factText(fact), index + 1, rankedFacts.length),
+          fanout: { returnedCount: facts.length, candidateCount: rankedFacts.length },
+          support: benchmarkFactSupport(fact),
+        }),
+      );
     }
     return deduplicateEdges(output);
   }
 
   private entityNeighbors(node: SearchNode, question: string): SearchEdge[] {
     const output: SearchEdge[] = [];
-    const chunkIds = this.rankChunkIds(this.chunksByEntity.get(node.id) ?? [], question).slice(
-      0,
-      this.fanout.entityChunks ?? 30,
+    output.push(
+      ...this.rankedChunkEdges(
+        node,
+        this.chunksByEntity.get(node.id) ?? [],
+        question,
+        this.fanout.entityChunks ?? 30,
+        "extracted",
+      ),
     );
-    for (const chunkId of chunkIds) {
-      output.push(edge(node, { kind: "chunk", id: chunkId }, "ground", 0.85));
-    }
-    const facts = this.rankFacts(this.factsByEntity.get(node.id) ?? [], question).slice(
-      0,
-      this.fanout.entityFacts ?? 30,
-    );
-    for (const fact of facts) {
-      output.push(edge(node, { kind: "fact", id: fact.id }, "expand", 0.9));
+    const rankedFacts = this.rankFacts(this.factsByEntity.get(node.id) ?? [], question);
+    const facts = rankedFacts.slice(0, this.fanout.entityFacts ?? 30);
+    for (const [index, fact] of facts.entries()) {
+      output.push(
+        edge(node, { kind: "fact", id: fact.id }, "expand", {
+          structural: { kind: "extracted" },
+          query: rankedQueryObservation(question, factText(fact), index + 1, rankedFacts.length),
+          fanout: { returnedCount: facts.length, candidateCount: rankedFacts.length },
+          support: benchmarkFactSupport(fact),
+        }),
+      );
     }
     return deduplicateEdges(output);
   }
@@ -220,15 +287,48 @@ export class BidirectionalBenchmarkSearchGraph implements SearchGraphPort {
     const fact = this.factsById.get(node.id);
     if (!fact) return [];
     return deduplicateEdges([
-      edge(node, { kind: "chunk", id: fact.edge.chunkId }, "ground", 1),
-      edge(node, { kind: "entity", id: fact.edge.src }, "expand", 0.95),
-      edge(node, { kind: "entity", id: fact.edge.dst }, "expand", 0.95),
+      edge(node, { kind: "chunk", id: fact.edge.chunkId }, "ground", {
+        structural: { kind: "deterministic" },
+        support: benchmarkFactSupport(fact),
+      }),
+      edge(node, { kind: "entity", id: fact.edge.src }, "expand", {
+        structural: { kind: "extracted" },
+        support: benchmarkFactSupport(fact),
+      }),
+      edge(node, { kind: "entity", id: fact.edge.dst }, "expand", {
+        structural: { kind: "extracted" },
+        support: benchmarkFactSupport(fact),
+      }),
     ]);
   }
 
   private rankChunkIds(chunkIds: readonly string[], question: string): string[] {
     if (!this.fanout.queryAware) return [...chunkIds];
     return this.lexicalRanker.rankChunkIds(question, chunkIds);
+  }
+
+  private rankedChunkEdges(
+    from: SearchNode,
+    chunkIds: readonly string[],
+    question: string,
+    limit: number,
+    structuralKind: "deterministic" | "extracted",
+  ): SearchEdge[] {
+    const ranked = this.rankChunkIds(chunkIds, question);
+    const selected = ranked.slice(0, limit);
+    return selected.map((chunkId, index) =>
+      edge(from, { kind: "chunk", id: chunkId }, "ground", {
+        structural: { kind: structuralKind },
+        query: rankedQueryObservation(
+          question,
+          this.docsById.get(chunkId)?.body ?? chunkId,
+          index + 1,
+          ranked.length,
+        ),
+        fanout: { returnedCount: selected.length, candidateCount: ranked.length },
+        supportApplicability: "not-applicable",
+      }),
+    );
   }
 
   private rankEntityIds(entityIds: readonly string[], question: string): string[] {
@@ -244,6 +344,39 @@ export class BidirectionalBenchmarkSearchGraph implements SearchGraphPort {
       (fact) => `${fact.edge.src} ${fact.edge.predicate} ${fact.edge.dst}`,
     );
   }
+}
+
+function addChunkProviderConsensus(seeds: readonly SearchSeed[]): SearchSeed[] {
+  const availableProviders = new Set(
+    seeds
+      .filter((seed) => seed.node.kind === "chunk")
+      .flatMap((seed) => seed.observations?.providers ?? []),
+  );
+  if (availableProviders.size <= 1) return [...seeds];
+  return seeds.map((seed) => {
+    if (seed.node.kind !== "chunk") return seed;
+    const query = seed.observations?.query;
+    if (!query) return seed;
+    const providerScores = [
+      query.lexical ? rankedConsensusScore(query.lexical.rank, query.lexical.candidateCount) : 0,
+      query.vector ? rankedConsensusScore(query.vector.rank, query.vector.candidateCount) : 0,
+    ];
+    const consensus =
+      providerScores.reduce((sum, score) => sum + score, 0) / availableProviders.size;
+    return {
+      ...seed,
+      observations: {
+        ...seed.observations,
+        query: { ...query, rerankerScore: consensus },
+      },
+    };
+  });
+}
+
+function rankedConsensusScore(rank: number, candidateCount: number): number {
+  const candidates = Math.max(1, Math.floor(candidateCount));
+  const boundedRank = Math.min(candidates, Math.max(1, Math.floor(rank)));
+  return candidates === 1 ? 1 : (candidates - boundedRank) / (candidates - 1);
 }
 
 interface IndexedLexicalDocument {
@@ -339,9 +472,9 @@ function edge(
   from: SearchNode,
   to: SearchNode,
   operation: SearchEdge["operation"],
-  confidence: number,
+  observations: SearchEdgeObservations,
 ): SearchEdge {
-  return { from, to, operation, confidence, queryRelevance: 0.8, evidenceSupport: 0.8 };
+  return { from, to, operation, observations };
 }
 
 function append<T>(map: Map<string, T[]>, key: string, value: T): void {
@@ -354,24 +487,44 @@ function nodeKey(node: SearchNode): string {
   return `${node.kind}:${node.id}`;
 }
 
-function deduplicateSeeds(seeds: readonly SearchSeed[]): SearchSeed[] {
-  const best = new Map<string, SearchSeed>();
-  for (const seed of seeds) {
-    const key = nodeKey(seed.node);
-    const previous = best.get(key);
-    if (!previous || seed.score > previous.score) best.set(key, seed);
-  }
-  return Array.from(best.values());
-}
-
 function deduplicateEdges(edges: readonly SearchEdge[]): SearchEdge[] {
   const best = new Map<string, SearchEdge>();
   for (const candidate of edges) {
     const key = `${candidate.operation}:${nodeKey(candidate.to)}`;
     const previous = best.get(key);
-    if (!previous || candidate.confidence > previous.confidence) best.set(key, candidate);
+    if (!previous) best.set(key, candidate);
   }
   return Array.from(best.values());
+}
+
+function rankedQueryObservation(
+  question: string,
+  text: string,
+  rank: number,
+  candidateCount: number,
+): NonNullable<SearchEdgeObservations["query"]> {
+  return {
+    lexical: {
+      rank,
+      candidateCount: Math.max(1, candidateCount),
+      normalizedScore: lexicalRelevance(question, text),
+    },
+  };
+}
+
+function factText(fact: IndexedFact): string {
+  return `${fact.edge.src} ${fact.edge.predicate} ${fact.edge.dst}`;
+}
+
+function benchmarkFactSupport(_fact: IndexedFact): SearchEdgeObservations["support"] {
+  return {
+    activeEvidenceCount: 1,
+    curatedEvidenceCount: 0,
+    derivedEvidenceCount: 1,
+    distinctResourceCount: 1,
+    conflictCount: 0,
+    staleEvidenceCount: 0,
+  };
 }
 
 function rankByQuestion<T>(
@@ -470,8 +623,4 @@ function stemTerm(term: string): string {
   if (term.length >= 5 && term.endsWith("es")) return term.slice(0, -2);
   if (term.length >= 4 && term.endsWith("s")) return term.slice(0, -1);
   return term;
-}
-
-function reciprocalRank(rank: number, weight: number): number {
-  return weight / (60 + rank);
 }

--- a/bench/src/rag-eval-v2/adaptive-benchmark-graph.test.ts
+++ b/bench/src/rag-eval-v2/adaptive-benchmark-graph.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { BidirectionalBenchmarkSearchGraph } from "../bidirectional-benchmark-search-graph.js";
+
+describe("BidirectionalBenchmarkSearchGraph adaptive observations", () => {
+  it("derives chunk seed consensus from the providers available for that query", async () => {
+    const graph = new BidirectionalBenchmarkSearchGraph(
+      { entities: new Map(), edges: [], chunkToEntities: new Map() },
+      [
+        { id: "both", title: "alpha", body: "alpha evidence" },
+        { id: "vector-only", title: "beta", body: "beta evidence" },
+        { id: "lexical-only", title: "alpha extra", body: "alpha secondary" },
+      ],
+      [{ question: "alpha", chunkIds: ["both", "vector-only", "lexical-only"] }],
+      { seedChunks: 3, lexicalSeedChunks: 2, providerConsensus: true },
+    );
+
+    const seeds = await graph.seed("alpha", {
+      organizationId: "test",
+      subjectId: "test",
+      groupIds: [],
+    });
+    const byId = new Map(seeds.map((seed) => [seed.node.id, seed]));
+
+    expect(byId.get("both")?.observations).toMatchObject({
+      providers: ["benchmark-lexical", "benchmark-vector"],
+      query: { rerankerScore: 1 },
+    });
+    expect(byId.get("vector-only")?.observations?.query?.rerankerScore).toBeLessThan(0.5);
+  });
+
+  it("reports full resource fanout and query-local rank on a bounded chunk list", async () => {
+    const docs = Array.from({ length: 100 }, (_, index) => ({
+      id: `guide-${index}`,
+      title: `guide chunk ${index}`,
+      body: index === 0 ? "specific treatment answer" : `unrelated material ${index}`,
+    }));
+    const graph = new BidirectionalBenchmarkSearchGraph(
+      {
+        entities: new Map(),
+        edges: [],
+        chunkToEntities: new Map(),
+      },
+      docs,
+      [],
+      { queryAware: true, resourceChunks: 10 },
+    );
+
+    const edges = await graph.neighbors({ kind: "resource", id: "guide" }, "specific treatment", {
+      organizationId: "test",
+      subjectId: "test",
+      groupIds: [],
+    });
+
+    expect(edges).toHaveLength(10);
+    expect(edges[0]).toMatchObject({
+      to: { kind: "chunk", id: "guide-0" },
+      observations: {
+        query: { lexical: { rank: 1, candidateCount: 100 } },
+        fanout: { returnedCount: 10, candidateCount: 100 },
+        supportApplicability: "not-applicable",
+      },
+    });
+  });
+});

--- a/bench/src/rag-eval-v2/compare-retrieval-runs.ts
+++ b/bench/src/rag-eval-v2/compare-retrieval-runs.ts
@@ -1,0 +1,267 @@
+// @ts-nocheck -- standalone benchmark artifact inspector for evolving JSONL schemas
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defaultDatasetPaths, loadDataset } from "./datasets.js";
+import { bootstrapMean95Ci, contextPrecisionForQuery, evidenceRecallForQuery } from "./metrics.js";
+
+const [datasetId, baselinePath, candidatePath, outputPath] = process.argv.slice(2);
+if (!datasetId || !baselinePath || !candidatePath) {
+  throw new Error(
+    "Usage: compare-retrieval-runs.ts <dataset-id> <baseline.jsonl> <candidate.jsonl> [output.json]",
+  );
+}
+const repositoryRoot = resolve(fileURLToPath(import.meta.url), "../../../..");
+const bundle = loadDataset(datasetId, defaultDatasetPaths(repositoryRoot));
+const baseline = readJsonl(resolve(baselinePath));
+const candidate = readJsonl(resolve(candidatePath));
+
+const result = {
+  generatedAt: new Date().toISOString(),
+  datasetId,
+  comparison: compareRuns(bundle, baseline, candidate),
+  baseline: summarizeRun(bundle, baseline),
+  candidate: summarizeRun(bundle, candidate),
+};
+
+if (outputPath) writeFileSync(resolve(outputPath), `${JSON.stringify(result, null, 2)}\n`);
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function compareRuns(bundle, baselineRows, candidateRows) {
+  const baseline = new Map(baselineRows.map((row) => [row.queryId, row]));
+  const candidate = new Map(candidateRows.map((row) => [row.queryId, row]));
+  const pairs = bundle.queries.flatMap((query) => {
+    const before = baseline.get(query.id);
+    const after = candidate.get(query.id);
+    if (before?.status !== "ok" || after?.status !== "ok") return [];
+    const beforeRecall = evidenceRecallForQuery(query, before.evidence);
+    const afterRecall = evidenceRecallForQuery(query, after.evidence);
+    const beforePrecision = contextPrecisionForQuery(query, before.evidence);
+    const afterPrecision = contextPrecisionForQuery(query, after.evidence);
+    if (
+      beforeRecall === null ||
+      afterRecall === null ||
+      beforePrecision === null ||
+      afterPrecision === null
+    )
+      return [];
+    const beforeIds = new Set(before.evidence.map((item) => item.id));
+    const afterIds = new Set(after.evidence.map((item) => item.id));
+    return [
+      {
+        query,
+        beforeRecall,
+        afterRecall,
+        beforePrecision,
+        afterPrecision,
+        recallDelta: afterRecall - beforeRecall,
+        precisionDelta: afterPrecision - beforePrecision,
+        overlap:
+          [...beforeIds].filter((id) => afterIds.has(id)).length /
+          Math.max(1, Math.min(10, beforeIds.size, afterIds.size)),
+        beforeDirect: directRatio(before),
+        afterDirect: directRatio(after),
+      },
+    ];
+  });
+  return {
+    pairedQueries: pairs.length,
+    all: pairSummary(pairs),
+    development: pairSummary(pairs.filter(({ query }) => !isHoldout(query.id))),
+    holdout: pairSummary(pairs.filter(({ query }) => isHoldout(query.id))),
+    byCategory: Object.fromEntries(
+      [...new Set(pairs.map(({ query }) => query.category))]
+        .sort()
+        .map((category) => [
+          category,
+          pairSummary(pairs.filter(({ query }) => query.category === category)),
+        ]),
+    ),
+  };
+}
+
+function pairSummary(pairs) {
+  const recallDeltas = pairs.map((pair) => pair.recallDelta);
+  const precisionDeltas = pairs.map((pair) => pair.precisionDelta);
+  return {
+    queries: pairs.length,
+    baselineRecall: mean(pairs.map((pair) => pair.beforeRecall)),
+    candidateRecall: mean(pairs.map((pair) => pair.afterRecall)),
+    recallDelta: mean(recallDeltas),
+    recallDelta95Ci: recallDeltas.length ? bootstrapMean95Ci(recallDeltas, 10_000, 20260824) : null,
+    baselinePrecision: mean(pairs.map((pair) => pair.beforePrecision)),
+    candidatePrecision: mean(pairs.map((pair) => pair.afterPrecision)),
+    precisionDelta: mean(precisionDeltas),
+    precisionDelta95Ci: precisionDeltas.length
+      ? bootstrapMean95Ci(precisionDeltas, 10_000, 20260824)
+      : null,
+    recallWins: recallDeltas.filter((value) => value > 0).length,
+    recallTies: recallDeltas.filter((value) => value === 0).length,
+    recallLosses: recallDeltas.filter((value) => value < 0).length,
+    meanTop10Overlap: mean(pairs.map((pair) => pair.overlap)),
+    baselineDirectEvidenceRatio: mean(pairs.map((pair) => pair.beforeDirect)),
+    candidateDirectEvidenceRatio: mean(pairs.map((pair) => pair.afterDirect)),
+  };
+}
+
+function summarizeRun(bundle, rows) {
+  const byQuery = new Map(rows.map((row) => [row.queryId, row]));
+  const values = bundle.queries.flatMap((query) => {
+    const row = byQuery.get(query.id);
+    if (row?.status !== "ok") return [];
+    const recall = evidenceRecallForQuery(query, row.evidence);
+    const precision = contextPrecisionForQuery(query, row.evidence);
+    return recall === null || precision === null ? [] : [{ query, row, recall, precision }];
+  });
+  const stoppedBy = countBy(rows, (row) => row.evidence[0]?.metadata?.stoppedBy ?? "missing");
+  const selectedEvidence = values.flatMap(({ row }) => row.evidence);
+  const selectedByPathShape = new Map();
+  const selectedBySeedProviders = new Map();
+  for (const { query, row } of values) {
+    for (const evidence of row.evidence) {
+      const shape = pathShape(evidence);
+      const entries = selectedByPathShape.get(shape) ?? [];
+      entries.push(contextPrecisionForQuery(query, [evidence]) ?? 0);
+      selectedByPathShape.set(shape, entries);
+      const providers = seedProviderProfile(evidence);
+      const providerEntries = selectedBySeedProviders.get(providers) ?? [];
+      providerEntries.push(contextPrecisionForQuery(query, [evidence]) ?? 0);
+      selectedBySeedProviders.set(providers, providerEntries);
+    }
+  }
+  const selectedMissingSignals = new Map();
+  for (const evidence of selectedEvidence) {
+    const breakdown = scoreBreakdown(evidence);
+    if (!breakdown) continue;
+    for (const signal of [
+      ...breakdown.seed.missingSignals,
+      ...breakdown.edges.flatMap((edge) => edge.missingSignals),
+      ...breakdown.evidence.missingSignals,
+    ]) {
+      selectedMissingSignals.set(signal, (selectedMissingSignals.get(signal) ?? 0) + 1);
+    }
+  }
+  const missingSignals = new Map();
+  for (const row of rows) {
+    const unique = new Set();
+    for (const evidence of row.evidence) {
+      const encoded = evidence.metadata?.missingSignals;
+      if (typeof encoded !== "string") continue;
+      for (const signal of encoded.split(",").filter(Boolean)) unique.add(signal);
+    }
+    for (const signal of unique) missingSignals.set(signal, (missingSignals.get(signal) ?? 0) + 1);
+  }
+  return {
+    queries: values.length,
+    recall: mean(values.map(({ recall }) => recall)),
+    precision: mean(values.map(({ precision }) => precision)),
+    development: metricSummary(values.filter(({ query }) => !isHoldout(query.id))),
+    holdout: metricSummary(values.filter(({ query }) => isHoldout(query.id))),
+    directEvidenceRatio: mean(values.map(({ row }) => directRatio(row))),
+    averageEvidence: mean(values.map(({ row }) => row.evidence.length)),
+    averagePathLength: mean(values.flatMap(({ row }) => row.evidence.map(pathLength))),
+    selectedPathShapes: countBy(selectedEvidence, pathShape),
+    precisionByPathShape: Object.fromEntries(
+      [...selectedByPathShape.entries()].map(([shape, precisions]) => [shape, mean(precisions)]),
+    ),
+    precisionBySeedProviders: Object.fromEntries(
+      [...selectedBySeedProviders.entries()].map(([providers, precisions]) => [
+        providers,
+        { selected: precisions.length, precision: mean(precisions) },
+      ]),
+    ),
+    meanSeedScoreByPathShape: Object.fromEntries(
+      [...new Set(selectedEvidence.map(pathShape))].map((shape) => [
+        shape,
+        mean(
+          selectedEvidence
+            .filter((evidence) => pathShape(evidence) === shape)
+            .flatMap((evidence) => {
+              const breakdown = scoreBreakdown(evidence);
+              return breakdown ? [breakdown.seed.score] : [];
+            }),
+        ),
+      ]),
+    ),
+    stoppedBy,
+    queriesWithMissingSignal: Object.fromEntries(
+      [...missingSignals.entries()].sort((left, right) => right[1] - left[1]),
+    ),
+    selectedEvidenceMissingSignals: Object.fromEntries(
+      [...selectedMissingSignals.entries()].sort((left, right) => right[1] - left[1]),
+    ),
+    scoringProfile: rows.find((row) => row.scoringProfile)?.scoringProfile ?? null,
+    featureSchemaVersion:
+      rows.find((row) => row.featureSchemaVersion)?.featureSchemaVersion ?? null,
+  };
+}
+
+function metricSummary(values) {
+  return {
+    queries: values.length,
+    recall: mean(values.map(({ recall }) => recall)),
+    precision: mean(values.map(({ precision }) => precision)),
+  };
+}
+
+function directRatio(row) {
+  if (row.evidence.length === 0) return 0;
+  return row.evidence.filter((item) => !item.metadata?.path).length / row.evidence.length;
+}
+
+function pathLength(evidence) {
+  const path = evidence.metadata?.path;
+  return typeof path === "string" && path ? path.split(" | ").length : 0;
+}
+
+function pathShape(evidence) {
+  const path = evidence.metadata?.path;
+  if (typeof path !== "string" || !path) return "direct-chunk-seed";
+  const edges = path.split(" | ");
+  const first = edges[0] ?? "unknown";
+  if (first.startsWith("entity:")) return "entity-seed-path";
+  if (first.startsWith("chunk:") && first.includes("->resource:")) return "chunk-resource-path";
+  if (first.startsWith("chunk:")) return "chunk-graph-path";
+  return "other-path";
+}
+
+function scoreBreakdown(evidence) {
+  const encoded = evidence.metadata?.scoreBreakdown;
+  if (typeof encoded !== "string") return null;
+  try {
+    return JSON.parse(encoded);
+  } catch {
+    return null;
+  }
+}
+
+function seedProviderProfile(evidence) {
+  const breakdown = scoreBreakdown(evidence);
+  const providers = breakdown?.seed?.observations?.providers;
+  return typeof providers === "string" && providers ? providers : "missing";
+}
+
+function isHoldout(queryId) {
+  return createHash("sha256").update(queryId).digest().readUInt32BE(0) % 100 < 20;
+}
+
+function countBy(values, key) {
+  const counts = new Map();
+  for (const value of values) {
+    const item = key(value);
+    counts.set(item, (counts.get(item) ?? 0) + 1);
+  }
+  return Object.fromEntries([...counts.entries()].sort((left, right) => right[1] - left[1]));
+}
+
+function mean(values) {
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null;
+}
+
+function readJsonl(path) {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}

--- a/bench/src/rag-eval-v2/contracts.ts
+++ b/bench/src/rag-eval-v2/contracts.ts
@@ -88,6 +88,13 @@ export interface RetrievalResult {
   readonly error: string | null;
   readonly frameworkVersion: string;
   readonly configDigest: string;
+  readonly scoringProfile?: {
+    readonly id: string;
+    readonly version: number;
+    readonly digest: string;
+  };
+  readonly featureSchemaVersion?: string;
+  readonly candidatePoolDigest?: string;
   readonly answerPolicy?: AnswerPolicy;
 }
 

--- a/bench/src/rag-eval-v2/evaluate-direct-pool-routing.ts
+++ b/bench/src/rag-eval-v2/evaluate-direct-pool-routing.ts
@@ -1,0 +1,284 @@
+// @ts-nocheck -- standalone offline policy evaluator for evolving benchmark traces
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defaultDatasetPaths, loadDataset } from "./datasets.js";
+import { contextPrecisionForQuery, evidenceRecallForQuery } from "./metrics.js";
+
+const args = process.argv.slice(2);
+if (args.length < 6 || (args.length % 3 !== 0 && args.length % 3 !== 1)) {
+  throw new Error(
+    "Usage: evaluate-direct-pool-routing.ts <dataset-id> <baseline.jsonl> <expanded.jsonl> " +
+      "[<dataset-id> <baseline.jsonl> <expanded.jsonl> ...] [output.json]",
+  );
+}
+const outputPath = args.length % 3 === 1 ? args.pop() : undefined;
+const repositoryRoot = resolve(fileURLToPath(import.meta.url), "../../../..");
+const cases = [];
+for (let index = 0; index < args.length; index += 3) {
+  const datasetId = args[index];
+  const bundle = loadDataset(datasetId, defaultDatasetPaths(repositoryRoot));
+  const baseline = new Map(readJsonl(resolve(args[index + 1])).map((row) => [row.queryId, row]));
+  const expanded = new Map(readJsonl(resolve(args[index + 2])).map((row) => [row.queryId, row]));
+  for (const query of bundle.queries) {
+    const before = baseline.get(query.id);
+    const after = expanded.get(query.id);
+    if (before?.status !== "ok" || after?.status !== "ok") continue;
+    const beforeMetrics = metrics(query, before.evidence);
+    const afterMetrics = metrics(query, after.evidence);
+    cases.push({
+      datasetId,
+      queryId: query.id,
+      split: splitFor(query.id, query.category, query.answerable),
+      beforeMetrics,
+      afterMetrics,
+      features: routingFeatures(query.text, before.evidence, after.evidence),
+    });
+  }
+}
+
+const baseline = evaluatePolicy({ id: "baseline", alwaysBaseline: true }, cases);
+const evaluated = policyGrid().map((policy) => evaluatePolicy(policy, cases));
+const development = evaluated
+  .filter((result) => result.splits.development.expandedQueries > 0)
+  .filter((result) => nonRegresses(result, baseline, "development"))
+  .sort((left, right) => compareSplit(right.splits.development, left.splits.development))
+  .slice(0, 200);
+const validation = development
+  .filter((result) => nonRegresses(result, baseline, "validation"))
+  .sort((left, right) => {
+    const validationOrder = compareSplit(right.splits.validation, left.splits.validation);
+    return validationOrder !== 0
+      ? validationOrder
+      : compareSplit(right.splits.development, left.splits.development);
+  });
+const selected = validation[0] ?? null;
+const result = {
+  generatedAt: new Date().toISOString(),
+  protocol: {
+    splitSeed: "direct-pool-routing-v1",
+    policiesEvaluated: evaluated.length,
+    datasetIdentityFeature: false,
+    runtimeFeaturesOnly: true,
+    developmentEligible: development.length,
+    validationEligible: validation.length,
+    selection:
+      "Aggregate and per-dataset recall/precision must not regress on development and validation; holdout is read only after selection.",
+  },
+  baseline,
+  selected,
+  topDevelopment: development.slice(0, 10),
+  topValidation: validation.slice(0, 10),
+  outcomeDiagnostics: outcomeDiagnostics(cases),
+};
+if (outputPath) writeFileSync(resolve(outputPath), `${JSON.stringify(result, null, 2)}\n`);
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function policyGrid() {
+  const policies = [];
+  for (const minExpandedDual of [0, 2, 4, 6, 8]) {
+    for (const minDualGain of [-5, -2, 0, 1, 2, 3, 4]) {
+      for (const minMeanConsensus of [0, 0.25, 0.35, 0.45, 0.55, 0.65]) {
+        for (const maxBaselineDual of [2, 4, 6, 8, 10]) {
+          for (const minOverlap of [0, 0.8, 0.9]) {
+            const policy = {
+              minExpandedDual,
+              minDualGain,
+              minMeanConsensus,
+              maxBaselineDual,
+              minOverlap,
+            };
+            policies.push({ ...policy, id: policyId(policy) });
+          }
+        }
+      }
+    }
+  }
+  return policies;
+}
+
+function evaluatePolicy(policy, values) {
+  const decisions = values.map((item) => {
+    const expanded = !policy.alwaysBaseline && useExpanded(policy, item.features);
+    return {
+      datasetId: item.datasetId,
+      split: item.split,
+      expanded,
+      metrics: expanded ? item.afterMetrics : item.beforeMetrics,
+    };
+  });
+  return {
+    policy,
+    splits: Object.fromEntries(
+      ["development", "validation", "holdout", "all"].map((split) => [
+        split,
+        summarize(
+          split === "all" ? decisions : decisions.filter((decision) => decision.split === split),
+        ),
+      ]),
+    ),
+  };
+}
+
+function useExpanded(policy, features) {
+  return (
+    features.expandedDual >= policy.minExpandedDual &&
+    features.dualGain >= policy.minDualGain &&
+    features.meanConsensus >= policy.minMeanConsensus &&
+    features.baselineDual <= policy.maxBaselineDual &&
+    features.overlap >= policy.minOverlap
+  );
+}
+
+function routingFeatures(question, baseline, expanded) {
+  const baselineIds = new Set(baseline.map((evidence) => evidence.id));
+  const expandedIds = new Set(expanded.map((evidence) => evidence.id));
+  const baselineDual = baseline.filter((evidence) => providerCount(evidence) >= 2).length;
+  const expandedDual = expanded.filter((evidence) => providerCount(evidence) >= 2).length;
+  const consensus = expanded.map(consensusScore);
+  return {
+    baselineDual,
+    expandedDual,
+    dualGain: expandedDual - baselineDual,
+    meanConsensus: mean(consensus),
+    minimumConsensus: Math.min(...consensus),
+    overlap:
+      [...baselineIds].filter((id) => expandedIds.has(id)).length /
+      Math.max(1, Math.min(10, baselineIds.size, expandedIds.size)),
+    queryTerms: question.split(/[^\p{L}\p{N}]+/u).filter(Boolean).length,
+  };
+}
+
+function providerCount(evidence) {
+  const providers = scoreBreakdown(evidence)?.seed?.observations?.providers;
+  return typeof providers === "string" && providers ? providers.split(",").length : 0;
+}
+
+function consensusScore(evidence) {
+  return scoreBreakdown(evidence)?.seed?.observations?.reranker ?? 0;
+}
+
+function scoreBreakdown(evidence) {
+  const encoded = evidence.metadata?.scoreBreakdown;
+  if (typeof encoded !== "string") return null;
+  try {
+    return JSON.parse(encoded);
+  } catch {
+    return null;
+  }
+}
+
+function metrics(query, evidence) {
+  return {
+    recall: evidenceRecallForQuery(query, evidence) ?? 0,
+    precision: contextPrecisionForQuery(query, evidence) ?? 0,
+  };
+}
+
+function summarize(values) {
+  const byDataset = {};
+  for (const datasetId of new Set(values.map((value) => value.datasetId))) {
+    byDataset[datasetId] = metricSummary(values.filter((value) => value.datasetId === datasetId));
+  }
+  return { ...metricSummary(values), byDataset };
+}
+
+function metricSummary(values) {
+  return {
+    queries: values.length,
+    recall: mean(values.map((value) => value.metrics.recall)),
+    precision: mean(values.map((value) => value.metrics.precision)),
+    expandedQueries: values.filter((value) => value.expanded).length,
+  };
+}
+
+function nonRegresses(result, baseline, split) {
+  const candidate = result.splits[split];
+  const control = baseline.splits[split];
+  if (candidate.recall < control.recall || candidate.precision < control.precision) return false;
+  return Object.keys(control.byDataset).every((datasetId) => {
+    const left = candidate.byDataset[datasetId];
+    const right = control.byDataset[datasetId];
+    return left && left.recall >= right.recall && left.precision >= right.precision;
+  });
+}
+
+function compareSplit(left, right) {
+  return (
+    left.recall - right.recall ||
+    left.precision - right.precision ||
+    right.expandedQueries - left.expandedQueries
+  );
+}
+
+function outcomeDiagnostics(values) {
+  const rows = values.map((item) => ({
+    split: item.split,
+    recallDelta: item.afterMetrics.recall - item.beforeMetrics.recall,
+    precisionDelta: item.afterMetrics.precision - item.beforeMetrics.precision,
+    ...item.features,
+  }));
+  return Object.fromEntries(
+    ["development", "validation", "holdout", "all"].map((split) => {
+      const subset = split === "all" ? rows : rows.filter((row) => row.split === split);
+      return [
+        split,
+        {
+          positive: numericSummary(
+            subset.filter((row) => row.recallDelta > 0 || row.precisionDelta > 0),
+          ),
+          neutral: numericSummary(
+            subset.filter((row) => row.recallDelta === 0 && row.precisionDelta === 0),
+          ),
+          negative: numericSummary(
+            subset.filter((row) => row.recallDelta < 0 || row.precisionDelta < 0),
+          ),
+        },
+      ];
+    }),
+  );
+}
+
+function numericSummary(rows) {
+  return {
+    queries: rows.length,
+    means: Object.fromEntries(
+      [
+        "recallDelta",
+        "precisionDelta",
+        "baselineDual",
+        "expandedDual",
+        "dualGain",
+        "meanConsensus",
+        "minimumConsensus",
+        "overlap",
+        "queryTerms",
+      ].map((key) => [key, mean(rows.map((row) => row[key]))]),
+    ),
+  };
+}
+
+function splitFor(queryId, category, answerable) {
+  const bucket =
+    createHash("sha256")
+      .update(`direct-pool-routing-v1\0${category}\0${answerable}\0${queryId}`)
+      .digest()
+      .readUInt32BE(0) % 100;
+  return bucket < 60 ? "development" : bucket < 80 ? "validation" : "holdout";
+}
+
+function policyId(policy) {
+  return `e${policy.minExpandedDual}-g${policy.minDualGain}-c${policy.minMeanConsensus}-b${policy.maxBaselineDual}-o${policy.minOverlap}`;
+}
+
+function mean(values) {
+  return values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function readJsonl(path) {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}

--- a/bench/src/rag-eval-v2/evaluate-graph-admission.ts
+++ b/bench/src/rag-eval-v2/evaluate-graph-admission.ts
@@ -1,0 +1,482 @@
+// @ts-nocheck -- standalone offline policy evaluator for evolving benchmark traces
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defaultDatasetPaths, loadDataset } from "./datasets.js";
+import { contextPrecisionForQuery, evidenceRecallForQuery } from "./metrics.js";
+
+const args = process.argv.slice(2);
+if (args.length < 6 || (args.length % 3 !== 0 && args.length % 3 !== 1)) {
+  throw new Error(
+    "Usage: evaluate-graph-admission.ts <dataset-id> <direct.jsonl> <graph.jsonl> " +
+      "[<dataset-id> <direct.jsonl> <graph.jsonl> ...] [output.json]",
+  );
+}
+const hasOutput = args.length % 3 === 1;
+const outputPath = hasOutput ? args.pop() : undefined;
+const repositoryRoot = resolve(fileURLToPath(import.meta.url), "../../../..");
+const queryCases = [];
+for (let index = 0; index < args.length; index += 3) {
+  const datasetId = args[index];
+  const directPath = args[index + 1];
+  const graphPath = args[index + 2];
+  const bundle = loadDataset(datasetId, defaultDatasetPaths(repositoryRoot));
+  const directRows = new Map(readJsonl(resolve(directPath)).map((row) => [row.queryId, row]));
+  const graphRows = new Map(readJsonl(resolve(graphPath)).map((row) => [row.queryId, row]));
+  for (const query of bundle.queries) {
+    const direct = directRows.get(query.id);
+    const graph = graphRows.get(query.id);
+    if (direct?.status !== "ok" || graph?.status !== "ok") continue;
+    const directEvidence = [...direct.evidence].sort(byScore).slice(0, 10);
+    const directIds = new Set(directEvidence.map((evidence) => evidence.id));
+    queryCases.push({
+      datasetId,
+      query,
+      split: splitFor(query.id, query.category, query.answerable),
+      directEvidence,
+      directBoundary: directBoundaryFeatures(
+        directEvidence[directEvidence.length - 1],
+        directEvidence[0]?.score ?? 0,
+      ),
+      graphCandidates: graph.evidence
+        .filter((evidence) => evidence.metadata?.path && !directIds.has(evidence.id))
+        .map((evidence) => ({ evidence, features: featuresFor(evidence) }))
+        .sort((left, right) => byScore(left.evidence, right.evidence)),
+      metricCache: new Map(),
+    });
+  }
+}
+
+const policies = policyGrid();
+const directPolicy = {
+  id: "direct-only",
+  maxGraph: 0,
+  scoreMargin: Number.POSITIVE_INFINITY,
+  minRouteGate: 0,
+  minQueryEvidence: 0,
+  minSeedGate: 0,
+  minSupport: 0,
+  maxPathLength: 0,
+  shape: "none",
+};
+const baseline = evaluatePolicy(directPolicy, queryCases);
+const evaluated = policies.map((policy) => evaluatePolicy(policy, queryCases));
+const developmentShortlist = evaluated
+  .filter((result) => result.splits.development.graphSelected > 0)
+  .filter((result) => nonRegresses(result, baseline, "development"))
+  .sort((left, right) => compareSplit(right.splits.development, left.splits.development))
+  .slice(0, 100);
+const validationEligible = developmentShortlist.filter((result) =>
+  nonRegresses(result, baseline, "validation"),
+);
+const selected = [...validationEligible].sort((left, right) => {
+  const validation = compareSplit(right.splits.validation, left.splits.validation);
+  return validation !== 0
+    ? validation
+    : compareSplit(right.splits.development, left.splits.development);
+})[0];
+
+const result = {
+  generatedAt: new Date().toISOString(),
+  protocol: {
+    splitSeed: "graph-admission-v2",
+    selection:
+      "Require aggregate and per-dataset non-regression on development, then the same gate and lexicographic recall/precision selection on validation; holdout is reported only after selection.",
+    runtimeFeaturesOnly: true,
+    datasetIdentityFeature: false,
+    policiesEvaluated: policies.length,
+    developmentShortlist: developmentShortlist.length,
+    validationEligible: validationEligible.length,
+  },
+  baseline,
+  selected: selected ?? null,
+  topDevelopment: developmentShortlist.slice(0, 10),
+  topValidation: [...validationEligible]
+    .sort((left, right) => compareSplit(right.splits.validation, left.splits.validation))
+    .slice(0, 10),
+  graphCandidateDiagnostics: graphCandidateDiagnostics(queryCases),
+  swapOutcomeDiagnostics: swapOutcomeDiagnostics(queryCases),
+};
+if (outputPath) writeFileSync(resolve(outputPath), `${JSON.stringify(result, null, 2)}\n`);
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function policyGrid() {
+  const policies = [];
+  for (const scoreMargin of [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.7]) {
+    for (const minRouteGate of [0.4, 0.45, 0.5, 0.55, 0.6, 0.7, 0.8]) {
+      for (const minQueryEvidence of [0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75]) {
+        for (const minDirectWorstScore of [0, 0.1, 0.15, 0.18, 0.2]) {
+          for (const maxDirectWorstProviderCount of [1, 2]) {
+            const policy = {
+              maxGraph: 1,
+              scoreMargin,
+              minRouteGate,
+              minQueryEvidence,
+              minSeedGate: 0,
+              minSupport: 0,
+              maxPathLength: 1,
+              shape: "entity",
+              minDirectWorstScore,
+              maxDirectWorstProviderCount,
+            };
+            policies.push({ ...policy, id: policyId(policy) });
+          }
+        }
+      }
+    }
+  }
+  return policies;
+}
+
+function evaluatePolicy(policy, cases) {
+  const values = cases.map((item) => evaluateCase(policy, item));
+  const splits = Object.fromEntries(
+    ["development", "validation", "holdout", "all"].map((split) => [
+      split,
+      summarize(split === "all" ? values : values.filter((value) => value.split === split)),
+    ]),
+  );
+  return { policy, splits };
+}
+
+function evaluateCase(policy, item) {
+  const selected = applyPolicy(policy, item);
+  const signature = selected.map((evidence) => evidence.id).join("\0");
+  let metrics = item.metricCache.get(signature);
+  if (!metrics) {
+    metrics = {
+      recall: evidenceRecallForQuery(item.query, selected) ?? 0,
+      precision: contextPrecisionForQuery(item.query, selected) ?? 0,
+    };
+    item.metricCache.set(signature, metrics);
+  }
+  return {
+    datasetId: item.datasetId,
+    queryId: item.query.id,
+    split: item.split,
+    recall: metrics.recall,
+    precision: metrics.precision,
+    graphSelected: selected.filter((evidence) => evidence.metadata?.path).length,
+  };
+}
+
+function applyPolicy(policy, item) {
+  const selected = [...item.directEvidence];
+  if (policy.maxGraph === 0) return selected;
+  const eligible = item.graphCandidates
+    .filter(({ features }) => eligibleByFeatures(policy, features, item.directBoundary))
+    .sort((left, right) => byScore(left.evidence, right.evidence));
+  let inserted = 0;
+  for (const { evidence } of eligible) {
+    if (inserted >= policy.maxGraph || selected.some((candidate) => candidate.id === evidence.id)) {
+      continue;
+    }
+    selected.sort(byScore);
+    const displaced = selected[selected.length - 1];
+    if (!displaced || evidence.score < displaced.score * policy.scoreMargin) continue;
+    selected[selected.length - 1] = evidence;
+    inserted++;
+  }
+  return selected.sort(byScore).slice(0, 10);
+}
+
+function eligibleByFeatures(policy, features, boundary) {
+  if (features.pathLength > policy.maxPathLength) return false;
+  if (policy.shape !== "any" && features.shape !== policy.shape) return false;
+  return (
+    features.minRouteGate >= policy.minRouteGate &&
+    features.minQueryEvidence >= policy.minQueryEvidence &&
+    features.seedGate >= policy.minSeedGate &&
+    features.support >= policy.minSupport &&
+    boundary.directWorstScore >= (policy.minDirectWorstScore ?? 0) &&
+    boundary.directWorstProviderCount <=
+      (policy.maxDirectWorstProviderCount ?? Number.POSITIVE_INFINITY)
+  );
+}
+
+function featuresFor(evidence) {
+  const breakdown = scoreBreakdown(evidence);
+  const edges = breakdown?.edges ?? [];
+  return {
+    score: evidence.score,
+    shape: pathShape(evidence),
+    pathLength: pathLength(evidence),
+    minRouteGate: minimum(
+      edges.map((edge) => edge.factors?.adaptiveRouteGate),
+      1,
+    ),
+    minQueryEvidence: minimum(
+      edges.map((edge) => edge.factors?.routeQueryEvidence),
+      1,
+    ),
+    minQueryRank: minimum(
+      edges.map((edge) => edge.factors?.routeQueryRank),
+      1,
+    ),
+    minSelectivity: minimum(
+      edges.map((edge) => edge.factors?.fanoutSelectivity),
+      1,
+    ),
+    seedScore: breakdown?.seed?.score ?? evidence.score,
+    seedQuery: breakdown?.seed?.factors?.query ?? 1,
+    seedGate: breakdown?.seed?.factors?.adaptiveSeedGate ?? 1,
+    seedProviderCount: breakdown?.seed?.observations?.providerCount ?? 0,
+    support: breakdown?.evidence?.factors?.support ?? 1,
+  };
+}
+
+function directBoundaryFeatures(evidence, topScore) {
+  const breakdown = scoreBreakdown(evidence);
+  return {
+    directWorstScore: evidence.score,
+    directWorstToTop: topScore === 0 ? 1 : evidence.score / topScore,
+    directWorstSeedScore: breakdown?.seed?.score ?? evidence.score,
+    directWorstSeedQuery: breakdown?.seed?.factors?.query ?? 1,
+    directWorstProviderCount: breakdown?.seed?.observations?.providerCount ?? 0,
+    directWorstSupport: breakdown?.evidence?.factors?.support ?? 1,
+  };
+}
+
+function graphCandidateDiagnostics(cases) {
+  const values = [];
+  for (const item of cases) {
+    for (const { evidence, features } of item.graphCandidates) {
+      values.push({
+        split: item.split,
+        relevant: (contextPrecisionForQuery(item.query, [evidence]) ?? 0) > 0,
+        ...features,
+      });
+    }
+  }
+  return Object.fromEntries(
+    ["development", "validation", "holdout", "all"].map((split) => {
+      const subset = split === "all" ? values : values.filter((value) => value.split === split);
+      return [
+        split,
+        {
+          candidates: subset.length,
+          relevant: subset.filter((value) => value.relevant).length,
+          precision:
+            subset.length === 0
+              ? 0
+              : subset.filter((value) => value.relevant).length / subset.length,
+          byShape: Object.fromEntries(
+            ["entity", "resource", "other"].map((shape) => {
+              const shaped = subset.filter((value) => value.shape === shape);
+              return [
+                shape,
+                {
+                  candidates: shaped.length,
+                  relevant: shaped.filter((value) => value.relevant).length,
+                },
+              ];
+            }),
+          ),
+        },
+      ];
+    }),
+  );
+}
+
+function swapOutcomeDiagnostics(cases) {
+  const records = [];
+  for (const item of cases) {
+    const worst = item.directEvidence[item.directEvidence.length - 1];
+    const top = item.directEvidence[0];
+    if (!worst || !top) continue;
+    const baselineRecall = evidenceRecallForQuery(item.query, item.directEvidence) ?? 0;
+    const baselinePrecision = contextPrecisionForQuery(item.query, item.directEvidence) ?? 0;
+    const boundary = directBoundaryFeatures(worst, top.score);
+    for (const { evidence, features } of item.graphCandidates) {
+      const selected = [...item.directEvidence.slice(0, -1), evidence].sort(byScore);
+      const recall = evidenceRecallForQuery(item.query, selected) ?? 0;
+      const precision = contextPrecisionForQuery(item.query, selected) ?? 0;
+      records.push({
+        split: item.split,
+        recallDelta: recall - baselineRecall,
+        precisionDelta: precision - baselinePrecision,
+        graphToDirectWorst: worst.score === 0 ? 1 : evidence.score / worst.score,
+        ...boundary,
+        ...features,
+      });
+    }
+  }
+  return Object.fromEntries(
+    ["development", "validation", "holdout", "all"].map((split) => {
+      const subset = split === "all" ? records : records.filter((record) => record.split === split);
+      return [
+        split,
+        {
+          positive: numericSummary(
+            subset.filter((record) => record.recallDelta > 0 || record.precisionDelta > 0),
+          ),
+          neutral: numericSummary(
+            subset.filter((record) => record.recallDelta === 0 && record.precisionDelta === 0),
+          ),
+          negative: numericSummary(
+            subset.filter((record) => record.recallDelta < 0 || record.precisionDelta < 0),
+          ),
+        },
+      ];
+    }),
+  );
+}
+
+function numericSummary(records) {
+  const keys = [
+    "recallDelta",
+    "precisionDelta",
+    "graphToDirectWorst",
+    "score",
+    "pathLength",
+    "minRouteGate",
+    "minQueryEvidence",
+    "minQueryRank",
+    "minSelectivity",
+    "seedScore",
+    "seedQuery",
+    "seedGate",
+    "seedProviderCount",
+    "support",
+    "directWorstScore",
+    "directWorstToTop",
+    "directWorstSeedScore",
+    "directWorstSeedQuery",
+    "directWorstProviderCount",
+    "directWorstSupport",
+  ];
+  return {
+    candidates: records.length,
+    features: Object.fromEntries(
+      keys.map((key) => {
+        const values = records
+          .map((record) => record[key])
+          .filter((value) => typeof value === "number" && Number.isFinite(value))
+          .sort((left, right) => left - right);
+        return [
+          key,
+          {
+            mean: mean(values),
+            p25: quantile(values, 0.25),
+            p50: quantile(values, 0.5),
+            p75: quantile(values, 0.75),
+          },
+        ];
+      }),
+    ),
+  };
+}
+
+function summarize(values) {
+  const byDataset = {};
+  for (const datasetId of new Set(values.map((value) => value.datasetId))) {
+    byDataset[datasetId] = metricSummary(values.filter((value) => value.datasetId === datasetId));
+  }
+  return { ...metricSummary(values), byDataset };
+}
+
+function metricSummary(values) {
+  return {
+    queries: values.length,
+    recall: mean(values.map((value) => value.recall)),
+    precision: mean(values.map((value) => value.precision)),
+    graphSelected: values.reduce((sum, value) => sum + value.graphSelected, 0),
+  };
+}
+
+function compareSplit(left, right) {
+  return (
+    left.recall - right.recall ||
+    left.precision - right.precision ||
+    right.graphSelected - left.graphSelected
+  );
+}
+
+function nonRegresses(result, baseline, split) {
+  const candidate = result.splits[split];
+  const control = baseline.splits[split];
+  if (candidate.recall < control.recall || candidate.precision < control.precision) return false;
+  return Object.keys(control.byDataset).every((datasetId) => {
+    const candidateDataset = candidate.byDataset[datasetId];
+    const controlDataset = control.byDataset[datasetId];
+    return (
+      candidateDataset &&
+      candidateDataset.recall >= controlDataset.recall &&
+      candidateDataset.precision >= controlDataset.precision
+    );
+  });
+}
+
+function splitFor(queryId, category, answerable) {
+  const value = createHash("sha256")
+    .update(`graph-admission-v2\0${category}\0${answerable}\0${queryId}`)
+    .digest()
+    .readUInt32BE(0);
+  const bucket = value % 100;
+  return bucket < 60 ? "development" : bucket < 80 ? "validation" : "holdout";
+}
+
+function policyId(policy) {
+  return [
+    `g${policy.maxGraph}`,
+    `m${policy.scoreMargin}`,
+    `r${policy.minRouteGate}`,
+    `q${policy.minQueryEvidence}`,
+    `s${policy.minSeedGate}`,
+    `u${policy.minSupport}`,
+    `h${policy.maxPathLength}`,
+    policy.shape,
+    `d${policy.minDirectWorstScore ?? 0}`,
+    `p${policy.maxDirectWorstProviderCount ?? "any"}`,
+  ].join("-");
+}
+
+function pathLength(evidence) {
+  const path = evidence.metadata?.path;
+  return typeof path === "string" && path ? path.split(" | ").length : 0;
+}
+
+function pathShape(evidence) {
+  const path = evidence.metadata?.path;
+  if (typeof path !== "string" || !path) return "direct";
+  const first = path.split(" | ")[0] ?? "";
+  if (first.startsWith("entity:")) return "entity";
+  if (first.startsWith("chunk:") && first.includes("->resource:")) return "resource";
+  return "other";
+}
+
+function scoreBreakdown(evidence) {
+  const encoded = evidence.metadata?.scoreBreakdown;
+  if (typeof encoded !== "string") return null;
+  try {
+    return JSON.parse(encoded);
+  } catch {
+    return null;
+  }
+}
+
+function minimum(values, fallback) {
+  const numbers = values.filter((value) => typeof value === "number" && Number.isFinite(value));
+  return numbers.length === 0 ? fallback : Math.min(...numbers);
+}
+
+function byScore(left, right) {
+  return right.score - left.score || left.id.localeCompare(right.id);
+}
+
+function mean(values) {
+  return values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function quantile(values, fraction) {
+  if (values.length === 0) return 0;
+  return values[Math.min(values.length - 1, Math.floor(values.length * fraction))] ?? 0;
+}
+
+function readJsonl(path) {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}

--- a/bench/src/rag-eval-v2/frameworks.test.ts
+++ b/bench/src/rag-eval-v2/frameworks.test.ts
@@ -53,6 +53,31 @@ describe("kontext cache-only coverage modes", () => {
 
   it.each([
     [
+      "bidirectional-kg-direct-only-ablation",
+      "workspace-0.1.0+bidirectional-kg-v5-direct-only-ablation",
+    ],
+    ["bidirectional-kg-consensus-direct", "workspace-0.1.0+bidirectional-kg-v6-consensus-direct"],
+    ["source-hydrated-stack", "workspace-0.1.0+v4-source-hydrated-stack"],
+    [
+      "source-hydrated-direct-only-ablation",
+      "workspace-0.1.0+v4-source-hydrated-direct-only-ablation",
+    ],
+  ])("allows %s to run from embedding checkpoints without an API key", async (mode, version) => {
+    restoreEnvironment("OPENAI_API_KEY", undefined);
+    process.env.KONTEXT_RAG_EVAL_MODE = mode;
+
+    const adapter = createFrameworkAdapters(DEFAULT_RAG_EVAL_MANIFEST).find(
+      (candidate) => candidate.id === "kontext-brain",
+    );
+
+    await expect(adapter?.doctor()).resolves.toMatchObject({
+      status: "ready",
+      version,
+    });
+  });
+
+  it.each([
+    [
       "v14a-anchored-deterministic-soft-coverage-stack",
       "workspace-0.1.0+v14a-anchored-deterministic-soft-coverage-stack",
     ],

--- a/bench/src/rag-eval-v2/frameworks.ts
+++ b/bench/src/rag-eval-v2/frameworks.ts
@@ -12,7 +12,7 @@ import type {
   RetrievedEvidence,
 } from "./contracts.js";
 import { readJsonLines, writeJsonAtomic, writeJsonLines } from "./jsonl.js";
-import { KontextBrainAdapter } from "./kontext-framework.js";
+import { KontextBrainAdapter, type KontextRetrievalMode } from "./kontext-framework.js";
 import type { FrameworkManifest, RagEvalManifest } from "./manifest.js";
 import { manifestDigest } from "./manifest.js";
 import {
@@ -565,6 +565,12 @@ export function createFrameworkAdapters(manifest: RagEvalManifest): FrameworkAda
         retrievalMode: kontextRetrievalMode(process.env.KONTEXT_RAG_EVAL_MODE),
         benchmarkDataDirectory: process.env.KONTEXT_RAG_EVAL_BENCH_DATA_DIR,
         precomputedIndexDirectory: process.env.KONTEXT_RAG_EVAL_PRECOMPUTED_INDEX,
+        directVectorSeedCount: optionalPositiveInteger(
+          process.env.KONTEXT_DIRECT_VECTOR_SEED_COUNT,
+        ),
+        directLexicalSeedCount: optionalPositiveInteger(
+          process.env.KONTEXT_DIRECT_LEXICAL_SEED_COUNT,
+        ),
       });
     }
     if (framework.id === "vector-rag-reranker") {
@@ -574,30 +580,15 @@ export function createFrameworkAdapters(manifest: RagEvalManifest): FrameworkAda
   });
 }
 
-function kontextRetrievalMode(
-  value: string | undefined,
-):
-  | "legacy"
-  | "bidirectional-kg"
-  | "max-existing-stack"
-  | "source-hydrated-stack"
-  | "source-hydrated-llm-stack"
-  | "source-hydrated-llm-recall-safe-stack"
-  | "source-hydrated-llm-candidate-safe-stack"
-  | "source-hydrated-llm-coverage-aware-stack"
-  | "multi-query-standard-rerank-stack"
-  | "multi-query-coverage-aware-stack"
-  | "multi-query-plan-aware-coverage-stack"
-  | "multi-query-anchored-evidence-answer-stack"
-  | "corpus-complete-anchored-evidence-answer-stack"
-  | "v14a-anchored-deterministic-soft-coverage-stack"
-  | "v14b-anchored-deterministic-quota-coverage-stack"
-  | "adaptive-eece-stack" {
+function kontextRetrievalMode(value: string | undefined): KontextRetrievalMode {
   if (!value?.trim()) return "multi-query-anchored-evidence-answer-stack";
   if (
     value === "bidirectional-kg" ||
+    value === "bidirectional-kg-direct-only-ablation" ||
+    value === "bidirectional-kg-consensus-direct" ||
     value === "max-existing-stack" ||
     value === "source-hydrated-stack" ||
+    value === "source-hydrated-direct-only-ablation" ||
     value === "source-hydrated-llm-stack" ||
     value === "source-hydrated-llm-recall-safe-stack" ||
     value === "source-hydrated-llm-candidate-safe-stack" ||
@@ -614,6 +605,12 @@ function kontextRetrievalMode(
     return value;
   }
   throw new Error(`Unsupported KONTEXT_RAG_EVAL_MODE: ${value}`);
+}
+
+function optionalPositiveInteger(value: string | undefined): number | undefined {
+  if (!value?.trim()) return undefined;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function parseCommand(raw: string | undefined): readonly string[] | null {

--- a/bench/src/rag-eval-v2/kontext-framework.test.ts
+++ b/bench/src/rag-eval-v2/kontext-framework.test.ts
@@ -1118,7 +1118,26 @@ describe("KontextBrainAdapter bidirectional KG mode", () => {
     },
   );
 
-  it("routes retrieval through KontextAgent's evidence-backed branch", async () => {
+  it.each([
+    {
+      mode: "bidirectional-kg",
+      frameworkVersion: "workspace-0.1.0+bidirectional-kg-v5-adaptive-route-evidence",
+      resultMode: "bidirectional",
+      maxHops: 8,
+    },
+    {
+      mode: "bidirectional-kg-direct-only-ablation",
+      frameworkVersion: "workspace-0.1.0+bidirectional-kg-v5-direct-only-ablation",
+      resultMode: "bidirectional-direct-only-ablation",
+      maxHops: 0,
+    },
+    {
+      mode: "bidirectional-kg-consensus-direct",
+      frameworkVersion: "workspace-0.1.0+bidirectional-kg-v6-consensus-direct",
+      resultMode: "bidirectional-consensus-direct",
+      maxHops: 0,
+    },
+  ] as const)("routes $mode through KontextAgent's evidence-backed branch", async (scenario) => {
     const root = mkdtempSync(join(tmpdir(), "kontext-rag-eval-kg-"));
     temporaryDirectories.push(root);
     const dataDirectory = join(root, "data");
@@ -1140,7 +1159,7 @@ describe("KontextBrainAdapter bidirectional KG mode", () => {
 
     const adapter = new KontextBrainAdapter(DEFAULT_RAG_EVAL_MANIFEST, {
       embeddingClient: new FakeEmbeddingClient(),
-      retrievalMode: "bidirectional-kg",
+      retrievalMode: scenario.mode,
       benchmarkDataDirectory: dataDirectory,
     });
     const results = await adapter.retrieve(testBundle(), { workDirectory, topK: 1, candidateK: 1 });
@@ -1148,14 +1167,36 @@ describe("KontextBrainAdapter bidirectional KG mode", () => {
     expect(results).toHaveLength(1);
     expect(results[0]).toMatchObject({
       status: "ok",
-      frameworkVersion: "workspace-0.1.0+bidirectional-kg-v2",
+      frameworkVersion: scenario.frameworkVersion,
+      scoringProfile: {
+        id: "adaptive-route-v3",
+        version: 2,
+      },
+      featureSchemaVersion: "n-layer-adaptive-routing-v1",
       evidence: [
         {
           id: "chunk:med-0",
           text: "Alpha evidence establishes the requested fact.",
-          metadata: { retrievalMode: "bidirectional", chunkId: "med-0" },
+          metadata: { retrievalMode: scenario.resultMode, chunkId: "med-0", path: "" },
         },
       ],
+    });
+    const config = JSON.parse(
+      readFileSync(
+        join(
+          workDirectory,
+          "graphrag-bench-medical",
+          "kontext-brain",
+          "index",
+          "bidirectional-kg",
+          "kontext-kg-config.json",
+        ),
+        "utf8",
+      ),
+    );
+    expect(config).toMatchObject({
+      retrievalMode: scenario.resultMode,
+      searchBudget: { maxHops: scenario.maxHops },
     });
   });
 
@@ -1224,7 +1265,20 @@ describe("KontextBrainAdapter bidirectional KG mode", () => {
     );
   });
 
-  it("keeps source-hydrated retrieval in a separate v4 index and returns source windows", async () => {
+  it.each([
+    {
+      mode: "source-hydrated-stack",
+      resultMode: "v4-source-hydrated-stack",
+      frameworkVersion: "workspace-0.1.0+v4-source-hydrated-stack",
+      maxHops: 8,
+    },
+    {
+      mode: "source-hydrated-direct-only-ablation",
+      resultMode: "v4-source-hydrated-direct-only-ablation",
+      frameworkVersion: "workspace-0.1.0+v4-source-hydrated-direct-only-ablation",
+      maxHops: 0,
+    },
+  ] as const)("keeps $mode in a separate index and returns source windows", async (scenario) => {
     const root = mkdtempSync(join(tmpdir(), "kontext-rag-eval-source-hydrated-"));
     temporaryDirectories.push(root);
     const dataDirectory = join(root, "data");
@@ -1261,39 +1315,39 @@ describe("KontextBrainAdapter bidirectional KG mode", () => {
 
     const adapter = new KontextBrainAdapter(DEFAULT_RAG_EVAL_MANIFEST, {
       embeddingClient: new FakeEmbeddingClient(),
-      retrievalMode: "source-hydrated-stack",
+      retrievalMode: scenario.mode,
       benchmarkDataDirectory: dataDirectory,
     });
     const results = await adapter.retrieve(testBundle(), { workDirectory, topK: 1, candidateK: 1 });
 
     expect(results[0]).toMatchObject({
       status: "ok",
-      frameworkVersion: "workspace-0.1.0+v4-source-hydrated-stack",
+      frameworkVersion: scenario.frameworkVersion,
       evidence: [
         {
           id: "source-window:med:0-1",
           sourceId: "med",
           metadata: {
-            retrievalMode: "v4-source-hydrated-stack",
+            retrievalMode: scenario.resultMode,
             anchorChunkIds: "med-0",
             sourceChunkIds: "med-0,med-1",
           },
         },
       ],
     });
-    expect(
-      readFileSync(
-        join(
-          workDirectory,
-          "graphrag-bench-medical",
-          "kontext-brain",
-          "index",
-          "v4-source-hydrated-stack",
-          "kontext-kg-config.json",
-        ),
-        "utf8",
+    const config = readFileSync(
+      join(
+        workDirectory,
+        "graphrag-bench-medical",
+        "kontext-brain",
+        "index",
+        scenario.resultMode,
+        "kontext-kg-config.json",
       ),
-    ).toContain('"windowCharacters": 5000');
+      "utf8",
+    );
+    expect(config).toContain('"windowCharacters": 5000');
+    expect(JSON.parse(config)).toMatchObject({ graphBudget: { maxHops: scenario.maxHops } });
   });
 
   it("runs the same source/chunk stack on a canonical static corpus without dataset branches", async () => {

--- a/bench/src/rag-eval-v2/kontext-framework.ts
+++ b/bench/src/rag-eval-v2/kontext-framework.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  AdaptiveRouteTraversalScorePolicy,
   BidirectionalNLayerRetriever,
   type BidirectionalRetrievalInput,
   type BidirectionalRetrievalResult,
@@ -68,8 +69,11 @@ import {
 export type KontextRetrievalMode =
   | "legacy"
   | "bidirectional-kg"
+  | "bidirectional-kg-direct-only-ablation"
+  | "bidirectional-kg-consensus-direct"
   | "max-existing-stack"
   | "source-hydrated-stack"
+  | "source-hydrated-direct-only-ablation"
   | "source-hydrated-llm-stack"
   | "source-hydrated-llm-recall-safe-stack"
   | "source-hydrated-llm-candidate-safe-stack"
@@ -89,11 +93,20 @@ export interface KontextBrainAdapterOptions {
   readonly retrievalMode?: KontextRetrievalMode;
   readonly benchmarkDataDirectory?: string;
   readonly precomputedIndexDirectory?: string;
+  readonly directVectorSeedCount?: number;
+  readonly directLexicalSeedCount?: number;
 }
 
-const BIDIRECTIONAL_FRAMEWORK_VERSION = "workspace-0.1.0+bidirectional-kg-v2";
+const BIDIRECTIONAL_FRAMEWORK_VERSION =
+  "workspace-0.1.0+bidirectional-kg-v5-adaptive-route-evidence";
+const BIDIRECTIONAL_DIRECT_ONLY_FRAMEWORK_VERSION =
+  "workspace-0.1.0+bidirectional-kg-v5-direct-only-ablation";
+const BIDIRECTIONAL_CONSENSUS_DIRECT_FRAMEWORK_VERSION =
+  "workspace-0.1.0+bidirectional-kg-v6-consensus-direct";
 const MAX_EXISTING_STACK_FRAMEWORK_VERSION = "workspace-0.1.0+v3-max-existing-stack";
 const SOURCE_HYDRATED_STACK_FRAMEWORK_VERSION = "workspace-0.1.0+v4-source-hydrated-stack";
+const SOURCE_HYDRATED_DIRECT_ONLY_FRAMEWORK_VERSION =
+  "workspace-0.1.0+v4-source-hydrated-direct-only-ablation";
 const SOURCE_HYDRATED_LLM_STACK_FRAMEWORK_VERSION = "workspace-0.1.0+v5-source-hydrated-llm-stack";
 const SOURCE_HYDRATED_LLM_RECALL_SAFE_STACK_FRAMEWORK_VERSION =
   "workspace-0.1.0+v6-source-hydrated-llm-recall-safe-stack";
@@ -288,6 +301,8 @@ export class KontextBrainAdapter implements FrameworkAdapter {
   private readonly retrievalMode: KontextRetrievalMode;
   private readonly benchmarkDataDirectory: string;
   private readonly precomputedIndexDirectory: string | null;
+  private readonly directVectorSeedCount: number;
+  private readonly directLexicalSeedCount: number;
 
   constructor(
     private readonly manifest: RagEvalManifest,
@@ -300,6 +315,8 @@ export class KontextBrainAdapter implements FrameworkAdapter {
       options.benchmarkDataDirectory ??
       resolve(dirname(fileURLToPath(import.meta.url)), "../../data");
     this.precomputedIndexDirectory = options.precomputedIndexDirectory ?? null;
+    this.directVectorSeedCount = positiveSeedCount(options.directVectorSeedCount, 30);
+    this.directLexicalSeedCount = positiveSeedCount(options.directLexicalSeedCount, 20);
   }
 
   async doctor(): Promise<FrameworkDoctorResult> {
@@ -327,7 +344,14 @@ export class KontextBrainAdapter implements FrameworkAdapter {
         detail: "read-only precomputed expansions and embeddings; deterministic coverage selection",
       };
     }
-    if (this.retrievalMode !== "legacy") {
+    if (
+      this.retrievalMode !== "legacy" &&
+      this.retrievalMode !== "bidirectional-kg-direct-only-ablation" &&
+      this.retrievalMode !== "bidirectional-kg-consensus-direct" &&
+      this.retrievalMode !== "max-existing-stack" &&
+      this.retrievalMode !== "source-hydrated-stack" &&
+      this.retrievalMode !== "source-hydrated-direct-only-ablation"
+    ) {
       if (!this.embeddingClient) {
         return {
           frameworkId: this.id,
@@ -402,14 +426,42 @@ export class KontextBrainAdapter implements FrameworkAdapter {
         configDigest: manifestDigest(this.manifest),
       }));
     }
-    if (this.retrievalMode === "bidirectional-kg") {
-      return this.retrieveBidirectionalKg(bundle, options);
+    if (
+      this.retrievalMode === "bidirectional-kg" ||
+      this.retrievalMode === "bidirectional-kg-direct-only-ablation" ||
+      this.retrievalMode === "bidirectional-kg-consensus-direct"
+    ) {
+      const consensusDirect = this.retrievalMode === "bidirectional-kg-consensus-direct";
+      return this.retrieveBidirectionalKg(
+        bundle,
+        options,
+        this.retrievalMode !== "bidirectional-kg",
+        consensusDirect,
+      );
     }
     if (this.retrievalMode === "max-existing-stack") {
       return this.retrieveMaxExistingStack(bundle, options);
     }
     if (this.retrievalMode === "source-hydrated-stack") {
       return this.retrieveMaxExistingStack(bundle, options, true);
+    }
+    if (this.retrievalMode === "source-hydrated-direct-only-ablation") {
+      return this.retrieveMaxExistingStack(
+        bundle,
+        options,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        null,
+        false,
+        true,
+      );
     }
     if (this.retrievalMode === "source-hydrated-llm-stack") {
       return this.retrieveMaxExistingStack(bundle, options, true, true);
@@ -646,8 +698,22 @@ export class KontextBrainAdapter implements FrameworkAdapter {
   private async retrieveBidirectionalKg(
     bundle: DatasetBundle,
     options: FrameworkRunOptions,
+    directOnly = false,
+    providerConsensus = false,
   ): Promise<RetrievalResult[]> {
-    const embeddingClient = this.embeddingClient;
+    const frameworkVersion = providerConsensus
+      ? BIDIRECTIONAL_CONSENSUS_DIRECT_FRAMEWORK_VERSION
+      : directOnly
+        ? BIDIRECTIONAL_DIRECT_ONLY_FRAMEWORK_VERSION
+        : BIDIRECTIONAL_FRAMEWORK_VERSION;
+    const retrievalMode = providerConsensus
+      ? "bidirectional-consensus-direct"
+      : directOnly
+        ? "bidirectional-direct-only-ablation"
+        : "bidirectional";
+    const maxHops = directOnly ? 0 : 8;
+    const embeddingClient =
+      this.embeddingClient ?? (directOnly ? cacheOnlyEmbeddingClient(this.manifest) : null);
     if (!embeddingClient) throw new Error("Bidirectional KG retrieval requires OPENAI_API_KEY");
     const artifact =
       bundle.track === "static-kb"
@@ -663,7 +729,7 @@ export class KontextBrainAdapter implements FrameworkAdapter {
         latencyMs: 0,
         inputTokens: null,
         error: `No evidence-backed KG artifact is registered for ${bundle.id}`,
-        frameworkVersion: BIDIRECTIONAL_FRAMEWORK_VERSION,
+        frameworkVersion,
         configDigest: manifestDigest(this.manifest),
       }));
     }
@@ -698,8 +764,14 @@ export class KontextBrainAdapter implements FrameworkAdapter {
       bundle.queries.map((query) => query.id),
       embeddingClient.dimensions,
     );
-    const vectorSeedCount = Math.min(10, docs.length);
-    const lexicalSeedCount = Math.min(5, docs.length);
+    const vectorSeedCount = Math.min(
+      providerConsensus ? this.directVectorSeedCount : 10,
+      docs.length,
+    );
+    const lexicalSeedCount = Math.min(
+      providerConsensus ? this.directLexicalSeedCount : 5,
+      docs.length,
+    );
     const seeds = bundle.queries.map((query) => {
       const queryVector = queryVectors.get(query.id);
       if (!queryVector) throw new Error(`Missing KG query embedding ${query.id}`);
@@ -725,17 +797,45 @@ export class KontextBrainAdapter implements FrameworkAdapter {
       entityFacts: 10,
       chunkEntities: 10,
       chunkFacts: 10,
+      providerConsensus,
     } as const;
     const searchGraph = new BidirectionalBenchmarkSearchGraph(graph, docs, seeds, graphFanout);
-    const knowledgeRetriever = new BidirectionalNLayerRetriever(searchGraph);
+    const scoringPolicy = new AdaptiveRouteTraversalScorePolicy();
+    const knowledgeRetriever = directOnly
+      ? new BudgetedBidirectionalRetriever(searchGraph, { maxHops })
+      : new BidirectionalNLayerRetriever(searchGraph, scoringPolicy);
     const agent = await this.createBidirectionalAgent(bundle, indexDirectory, knowledgeRetriever);
-    const digest = manifestDigest(this.manifest);
-    const checkpointDirectory = join(indexDirectory, "retrieval-checkpoints", queryDigest);
+    const candidatePoolDigest = createHash("sha256")
+      .update(queryDigest)
+      .update("\0")
+      .update(String(vectorSeedCount))
+      .update("\0")
+      .update(String(lexicalSeedCount))
+      .update("\0")
+      .update(providerConsensus ? "provider-consensus-v1" : "ordinal-fusion-v1")
+      .digest("hex");
+    const digest = createHash("sha256")
+      .update(manifestDigest(this.manifest))
+      .update("\0")
+      .update(scoringPolicy.descriptor.profileDigest)
+      .update("\0")
+      .update(scoringPolicy.descriptor.featureSchemaVersion)
+      .update("\0")
+      .update(frameworkVersion)
+      .update("\0")
+      .update(candidatePoolDigest)
+      .digest("hex");
+    const checkpointDirectory = join(indexDirectory, "retrieval-checkpoints", candidatePoolDigest);
     writeJsonAtomic(join(indexDirectory, "kontext-kg-config.json"), {
-      retrievalMode: "bidirectional",
-      frameworkVersion: BIDIRECTIONAL_FRAMEWORK_VERSION,
+      retrievalMode,
+      frameworkVersion,
       graphProjection: "GraphRAG-Bench KG -> production SearchGraphPort",
       agentEntryPoint: "KontextAgent.retrieve(question, principal)",
+      scoring: {
+        profile: scoringPolicy.descriptor,
+        featureSchemaVersion: scoringPolicy.descriptor.featureSchemaVersion,
+        candidatePoolDigest,
+      },
       embedding: {
         provider: "openai",
         model: embeddingClient.model,
@@ -746,7 +846,7 @@ export class KontextBrainAdapter implements FrameworkAdapter {
       graphFanout,
       searchBudget: {
         topK: options.topK,
-        maxHops: 8,
+        maxHops,
         maxKgHops: 3,
         maxVisited: 200,
         maxCandidates: 500,
@@ -780,7 +880,7 @@ export class KontextBrainAdapter implements FrameworkAdapter {
             checkpoint.frameworkId === this.id &&
             checkpoint.queryId === query.id &&
             checkpoint.configDigest === digest &&
-            checkpoint.frameworkVersion === BIDIRECTIONAL_FRAMEWORK_VERSION
+            checkpoint.frameworkVersion === frameworkVersion
           ) {
             return checkpoint;
           }
@@ -802,7 +902,7 @@ export class KontextBrainAdapter implements FrameworkAdapter {
           score: hit.score,
           rank: rank + 1,
           metadata: {
-            retrievalMode: "bidirectional",
+            retrievalMode,
             chunkId: hit.chunkId,
             factKey: hit.factKey ?? null,
             factStatus: hit.factStatus ?? null,
@@ -812,6 +912,11 @@ export class KontextBrainAdapter implements FrameworkAdapter {
             visited: trace?.visited ?? null,
             candidates: trace?.candidates ?? null,
             stoppedBy: trace?.stoppedBy ?? null,
+            scoringProfileId: trace?.scoring.profileId ?? null,
+            scoringProfileDigest: trace?.scoring.profileDigest ?? null,
+            missingSignals: trace?.scoring.missingSignals.join(",") ?? null,
+            adaptiveRouting: trace?.scoring.routing ? JSON.stringify(trace.scoring.routing) : null,
+            scoreBreakdown: hit.scoreBreakdown ? JSON.stringify(hit.scoreBreakdown) : null,
           },
         }));
         const result: RetrievalResult = {
@@ -823,8 +928,15 @@ export class KontextBrainAdapter implements FrameworkAdapter {
           latencyMs: performance.now() - startedAt,
           inputTokens: retrieval.contextTokensUsed,
           error: null,
-          frameworkVersion: BIDIRECTIONAL_FRAMEWORK_VERSION,
+          frameworkVersion,
           configDigest: digest,
+          scoringProfile: {
+            id: scoringPolicy.descriptor.profileId,
+            version: scoringPolicy.descriptor.profileVersion,
+            digest: scoringPolicy.descriptor.profileDigest,
+          },
+          featureSchemaVersion: scoringPolicy.descriptor.featureSchemaVersion,
+          candidatePoolDigest,
         };
         writeJsonAtomic(checkpointPath, result);
         return result;
@@ -838,8 +950,15 @@ export class KontextBrainAdapter implements FrameworkAdapter {
           latencyMs: performance.now() - startedAt,
           inputTokens: null,
           error: (error as Error).message,
-          frameworkVersion: BIDIRECTIONAL_FRAMEWORK_VERSION,
+          frameworkVersion,
           configDigest: digest,
+          scoringProfile: {
+            id: scoringPolicy.descriptor.profileId,
+            version: scoringPolicy.descriptor.profileVersion,
+            digest: scoringPolicy.descriptor.profileDigest,
+          },
+          featureSchemaVersion: scoringPolicy.descriptor.featureSchemaVersion,
+          candidatePoolDigest,
         };
         writeJsonAtomic(checkpointPath, result);
         return result;
@@ -861,10 +980,13 @@ export class KontextBrainAdapter implements FrameworkAdapter {
     anchoredEvidenceAnswer = false,
     deterministicCoverage: CacheOnlyCoverageDescriptor | null = null,
     completeCorpusCoverage = false,
+    directOnlyTraversal = false,
   ): Promise<RetrievalResult[]> {
     const embeddingClient =
       this.embeddingClient ??
-      (deterministicCoverage ? cacheOnlyEmbeddingClient(this.manifest) : null);
+      (deterministicCoverage || (!rerankWithLlm && !multiQuery)
+        ? cacheOnlyEmbeddingClient(this.manifest)
+        : null);
     if (!embeddingClient) throw new Error("Max existing stack retrieval requires OPENAI_API_KEY");
     const candidateCount = deterministicCoverage
       ? deterministicCoverage.candidateCount
@@ -892,13 +1014,14 @@ export class KontextBrainAdapter implements FrameworkAdapter {
                   : hydrateSourceContext
                     ? "v4-source-hydrated-stack"
                     : "v3-max-existing-stack";
-    const retrievalMode =
-      deterministicCoverage?.retrievalMode ??
-      (completeCorpusCoverage
-        ? V15_STACK_DESCRIPTOR.retrievalMode
-        : anchoredEvidenceAnswer
-          ? V13_STACK_DESCRIPTOR.retrievalMode
-          : inheritedRetrievalMode);
+    const retrievalMode = directOnlyTraversal
+      ? "v4-source-hydrated-direct-only-ablation"
+      : (deterministicCoverage?.retrievalMode ??
+        (completeCorpusCoverage
+          ? V15_STACK_DESCRIPTOR.retrievalMode
+          : anchoredEvidenceAnswer
+            ? V13_STACK_DESCRIPTOR.retrievalMode
+            : inheritedRetrievalMode));
     const inheritedFrameworkVersion = planAwareCoverage
       ? MULTI_QUERY_PLAN_AWARE_COVERAGE_STACK_FRAMEWORK_VERSION
       : multiQuery
@@ -918,13 +1041,14 @@ export class KontextBrainAdapter implements FrameworkAdapter {
                   : hydrateSourceContext
                     ? SOURCE_HYDRATED_STACK_FRAMEWORK_VERSION
                     : MAX_EXISTING_STACK_FRAMEWORK_VERSION;
-    const frameworkVersion =
-      deterministicCoverage?.frameworkVersion ??
-      (completeCorpusCoverage
-        ? V15_STACK_DESCRIPTOR.frameworkVersion
-        : anchoredEvidenceAnswer
-          ? V13_STACK_DESCRIPTOR.frameworkVersion
-          : inheritedFrameworkVersion);
+    const frameworkVersion = directOnlyTraversal
+      ? SOURCE_HYDRATED_DIRECT_ONLY_FRAMEWORK_VERSION
+      : (deterministicCoverage?.frameworkVersion ??
+        (completeCorpusCoverage
+          ? V15_STACK_DESCRIPTOR.frameworkVersion
+          : anchoredEvidenceAnswer
+            ? V13_STACK_DESCRIPTOR.frameworkVersion
+            : inheritedFrameworkVersion));
     const answerPolicy =
       deterministicCoverage?.answerPolicy ??
       (completeCorpusCoverage
@@ -969,6 +1093,7 @@ export class KontextBrainAdapter implements FrameworkAdapter {
           candidateCount,
           deterministicCoverage,
           completeCorpusCoverage,
+          directOnlyTraversal,
         ),
       }));
     }
@@ -1145,7 +1270,7 @@ export class KontextBrainAdapter implements FrameworkAdapter {
     } as const;
     const graphBudget = {
       topK: candidateCount,
-      maxHops: 8,
+      maxHops: directOnlyTraversal ? 0 : 8,
       maxKgHops: 3,
       maxVisited: 400,
       maxCandidates: 1_000,
@@ -1188,6 +1313,7 @@ export class KontextBrainAdapter implements FrameworkAdapter {
       candidateCount,
       deterministicCoverage,
       completeCorpusCoverage,
+      directOnlyTraversal,
     );
     const retrievalQueryDigest = multiQuery ? expandedQueryDigest : baseQueryDigest;
     const checkpointDirectory = join(indexDirectory, "retrieval-checkpoints", retrievalQueryDigest);
@@ -1780,7 +1906,7 @@ class BudgetedBidirectionalRetriever extends BidirectionalNLayerRetriever {
     graph: SearchGraphPort,
     private readonly defaultBudget: Readonly<Partial<SearchBudget>>,
   ) {
-    super(graph);
+    super(graph, new AdaptiveRouteTraversalScorePolicy());
   }
 
   override retrieve(input: BidirectionalRetrievalInput): Promise<BidirectionalRetrievalResult> {
@@ -1959,8 +2085,9 @@ function loadEmbeddingBatch(
       metadata.offset !== offset ||
       metadata.ids.length !== ids.length ||
       metadata.ids.some((id, index) => id !== ids[index])
-    )
+    ) {
       return null;
+    }
     if (
       metadata.schemaVersion === 2 &&
       (metadata.inputDigests.length !== inputs.length ||
@@ -2374,8 +2501,17 @@ function cacheOnlyEmbeddingClient(manifest: RagEvalManifest): EmbeddingClient {
 
 function frameworkVersion(mode: KontextRetrievalMode): string {
   if (mode === "bidirectional-kg") return BIDIRECTIONAL_FRAMEWORK_VERSION;
+  if (mode === "bidirectional-kg-direct-only-ablation") {
+    return BIDIRECTIONAL_DIRECT_ONLY_FRAMEWORK_VERSION;
+  }
+  if (mode === "bidirectional-kg-consensus-direct") {
+    return BIDIRECTIONAL_CONSENSUS_DIRECT_FRAMEWORK_VERSION;
+  }
   if (mode === "max-existing-stack") return MAX_EXISTING_STACK_FRAMEWORK_VERSION;
   if (mode === "source-hydrated-stack") return SOURCE_HYDRATED_STACK_FRAMEWORK_VERSION;
+  if (mode === "source-hydrated-direct-only-ablation") {
+    return SOURCE_HYDRATED_DIRECT_ONLY_FRAMEWORK_VERSION;
+  }
   if (mode === "source-hydrated-llm-stack") return SOURCE_HYDRATED_LLM_STACK_FRAMEWORK_VERSION;
   if (mode === "source-hydrated-llm-recall-safe-stack") {
     return SOURCE_HYDRATED_LLM_RECALL_SAFE_STACK_FRAMEWORK_VERSION;
@@ -2411,6 +2547,10 @@ function frameworkVersion(mode: KontextRetrievalMode): string {
   return "workspace-0.1.0";
 }
 
+function positiveSeedCount(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && (value ?? 0) > 0 ? Math.floor(value as number) : fallback;
+}
+
 function maxExistingStackDigest(
   manifest: RagEvalManifest,
   hydrateSourceContext = false,
@@ -2425,6 +2565,7 @@ function maxExistingStackDigest(
   candidateCount = MAX_EXISTING_STACK_CANDIDATES,
   deterministicCoverage: CacheOnlyCoverageDescriptor | null = null,
   completeCorpusCoverage = false,
+  directOnlyTraversal = false,
 ): string {
   const inheritedStackIdentity = planAwareCoverage
     ? `\0v12-multi-query-plan-aware-coverage-stack\0${MULTI_QUERY_POLICY_VERSION}\0`
@@ -2473,7 +2614,9 @@ function maxExistingStackDigest(
     .update(JSON.stringify(KNOWLEDGE_ARTIFACT_SELECTION_POLICY))
     .update(String(candidateCount))
     .update("\0")
-    .update(JSON.stringify(MAX_EXISTING_STACK_FUSION));
+    .update(JSON.stringify(MAX_EXISTING_STACK_FUSION))
+    .update("\0")
+    .update(directOnlyTraversal ? "direct-only-traversal" : "graph-traversal");
   if (hydrateSourceContext) {
     hash
       .update("\0")

--- a/bench/src/rag-eval-v2/kontext-retrieval-tune.ts
+++ b/bench/src/rag-eval-v2/kontext-retrieval-tune.ts
@@ -1,7 +1,11 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { performance } from "node:perf_hooks";
-import { BidirectionalNLayerRetriever, type Principal } from "@kontext-brain/core";
+import {
+  AdaptiveRouteTraversalScorePolicy,
+  BidirectionalNLayerRetriever,
+  type Principal,
+} from "@kontext-brain/core";
 import {
   type BenchmarkGraphFanout,
   BidirectionalBenchmarkSearchGraph,
@@ -86,7 +90,10 @@ const variants: readonly Variant[] = [
 for (const variant of variants) {
   const startedAt = performance.now();
   const searchGraph = new BidirectionalBenchmarkSearchGraph(graph, docs, seeds, variant.fanout);
-  const retriever = new BidirectionalNLayerRetriever(searchGraph);
+  const retriever = new BidirectionalNLayerRetriever(
+    searchGraph,
+    new AdaptiveRouteTraversalScorePolicy(),
+  );
   const recalls: number[] = [];
   const precisions: number[] = [];
   const evidenceCounts: number[] = [];

--- a/bench/src/rag-eval-v2/max-existing-stack-tune.ts
+++ b/bench/src/rag-eval-v2/max-existing-stack-tune.ts
@@ -1,7 +1,11 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { performance } from "node:perf_hooks";
-import { BidirectionalNLayerRetriever, type Principal } from "@kontext-brain/core";
+import {
+  AdaptiveRouteTraversalScorePolicy,
+  BidirectionalNLayerRetriever,
+  type Principal,
+} from "@kontext-brain/core";
 import { BidirectionalBenchmarkSearchGraph } from "../bidirectional-benchmark-search-graph.js";
 import type { BenchDoc } from "../corpus.js";
 import type { KGSerialized, KGStore } from "../kg-builder.js";
@@ -67,7 +71,10 @@ const searchGraph = new BidirectionalBenchmarkSearchGraph(graph, docs, seeds, {
   chunkEntities: 10,
   chunkFacts: 10,
 });
-const retriever = new BidirectionalNLayerRetriever(searchGraph);
+const retriever = new BidirectionalNLayerRetriever(
+  searchGraph,
+  new AdaptiveRouteTraversalScorePolicy(),
+);
 const bm25Ranker = new CorpusBm25Ranker(
   docs.map((doc) => ({ id: doc.id, text: `${doc.title} ${doc.body}` })),
 );

--- a/bench/src/rag-eval-v2/scoring-profile-evaluation.test.ts
+++ b/bench/src/rag-eval-v2/scoring-profile-evaluation.test.ts
@@ -1,0 +1,62 @@
+import { DEFAULT_CALIBRATED_SCORING_PROFILE } from "@kontext-brain/core";
+import { describe, expect, it } from "vitest";
+import {
+  type ScoringFeatureCandidate,
+  assignScoringSplits,
+  compareScoringProfiles,
+  evaluateScoringProfile,
+  selectProfileByValidation,
+} from "./scoring-profile-evaluation.js";
+
+const candidates: ScoringFeatureCandidate[] = [
+  candidate("q1", "relevant", true, 1),
+  candidate("q1", "noise", false, 5),
+  candidate("q2", "relevant-2", true, 1),
+  candidate("q2", "noise-2", false, 4),
+];
+
+describe("scoring profile evaluation", () => {
+  it("deterministically splits queries and evaluates ranking metrics", () => {
+    expect(assignScoringSplits(candidates)).toEqual(assignScoringSplits(candidates));
+    const evaluation = evaluateScoringProfile(DEFAULT_CALIBRATED_SCORING_PROFILE, candidates, 1);
+    expect(evaluation).toMatchObject({ queries: 2, recallAtK: 1, ndcgAtK: 1 });
+  });
+
+  it("uses paired bootstrap intervals and a recall guardrail for selection", () => {
+    const baseline = evaluateScoringProfile(DEFAULT_CALIBRATED_SCORING_PROFILE, candidates, 1);
+    const tuned = { ...baseline, profileId: "tuned", ndcgAtK: baseline.ndcgAtK + 0.01 };
+    expect(compareScoringProfiles(baseline, tuned, 100).ndcgDifference).toMatchObject({
+      mean: 0,
+    });
+    expect(selectProfileByValidation([tuned], baseline)?.profileId).toBe("tuned");
+  });
+});
+
+function candidate(
+  queryId: string,
+  candidateId: string,
+  relevant: boolean,
+  lexicalRank: number,
+): ScoringFeatureCandidate {
+  return {
+    queryId,
+    category: "lookup",
+    answerable: true,
+    candidateId,
+    relevant,
+    seed: {
+      observations: {
+        query: { lexical: { rank: lexicalRank, candidateCount: 5 } },
+      },
+    },
+    edges: [],
+    evidence: {
+      factStatus: "active",
+      observations: {
+        origin: "curated",
+        freshnessDays: 0,
+        support: { activeEvidenceCount: 1, distinctResourceCount: 1 },
+      },
+    },
+  };
+}

--- a/bench/src/rag-eval-v2/scoring-profile-evaluation.ts
+++ b/bench/src/rag-eval-v2/scoring-profile-evaluation.ts
@@ -1,0 +1,237 @@
+import {
+  CalibratedTraversalScorePolicy,
+  type EdgeScoreInput,
+  type EvidenceScoreInput,
+  type SeedScoreInput,
+  type TraversalScoringProfile,
+  scoringProfileDigest,
+} from "@kontext-brain/core";
+
+export type ScoringSplit = "development" | "validation" | "holdout";
+
+export interface ScoringFeatureCandidate {
+  readonly queryId: string;
+  readonly category: string;
+  readonly answerable: boolean;
+  readonly candidateId: string;
+  readonly relevant: boolean;
+  readonly seed: SeedScoreInput;
+  readonly edges: readonly EdgeScoreInput[];
+  readonly evidence: EvidenceScoreInput;
+}
+
+export interface ScoringProfileEvaluation {
+  readonly profileId: string;
+  readonly profileDigest: string;
+  readonly queries: number;
+  readonly recallAtK: number;
+  readonly ndcgAtK: number;
+  readonly missingSignalRatio: number;
+  readonly perQuery: Readonly<Record<string, { readonly recall: number; readonly ndcg: number }>>;
+}
+
+export interface ScoringProfileComparison {
+  readonly candidate: ScoringProfileEvaluation;
+  readonly recallDifference: BootstrapInterval;
+  readonly ndcgDifference: BootstrapInterval;
+}
+
+export interface BootstrapInterval {
+  readonly mean: number;
+  readonly lower95: number;
+  readonly upper95: number;
+}
+
+/** Deterministic stratification keeps tuning and final holdout queries separate. */
+export function assignScoringSplits(
+  candidates: readonly ScoringFeatureCandidate[],
+  seed = "kontext-scoring-v1",
+): ReadonlyMap<string, ScoringSplit> {
+  const queryMetadata = new Map<string, Pick<ScoringFeatureCandidate, "category" | "answerable">>();
+  for (const candidate of candidates) {
+    queryMetadata.set(candidate.queryId, {
+      category: candidate.category,
+      answerable: candidate.answerable,
+    });
+  }
+  const strata = new Map<string, string[]>();
+  for (const [queryId, metadata] of queryMetadata) {
+    const key = `${metadata.category}:${metadata.answerable}`;
+    const values = strata.get(key) ?? [];
+    values.push(queryId);
+    strata.set(key, values);
+  }
+  const assignments = new Map<string, ScoringSplit>();
+  for (const queryIds of strata.values()) {
+    queryIds.sort((left, right) => stableHash(`${seed}:${left}`) - stableHash(`${seed}:${right}`));
+    const developmentCount = Math.max(1, Math.floor(queryIds.length * 0.6));
+    const validationCount =
+      queryIds.length < 2 ? 0 : Math.max(1, Math.floor(queryIds.length * 0.2));
+    queryIds.forEach((queryId, index) => {
+      assignments.set(
+        queryId,
+        index < developmentCount
+          ? "development"
+          : index < developmentCount + validationCount
+            ? "validation"
+            : "holdout",
+      );
+    });
+  }
+  return assignments;
+}
+
+export function evaluateScoringProfile(
+  profile: TraversalScoringProfile,
+  candidates: readonly ScoringFeatureCandidate[],
+  k = 10,
+): ScoringProfileEvaluation {
+  const policy = new CalibratedTraversalScorePolicy(profile);
+  const byQuery = new Map<string, ScoredCandidate[]>();
+  let missing = 0;
+  let possibleSignals = 0;
+  for (const candidate of candidates) {
+    const seed = policy.seedScore(candidate.seed);
+    let pathScore = seed.score;
+    const computations = [seed];
+    candidate.edges.forEach((edge, index) => {
+      const scored = policy.edgeScore(pathScore, edge, index + 1);
+      pathScore = scored.score;
+      computations.push(scored);
+    });
+    const evidence = policy.evidenceScore(pathScore, candidate.evidence);
+    computations.push(evidence);
+    missing += computations.reduce((sum, item) => sum + item.missingSignals.length, 0);
+    possibleSignals += 1 + candidate.edges.length * 3 + 4;
+    const values = byQuery.get(candidate.queryId) ?? [];
+    values.push({ id: candidate.candidateId, relevant: candidate.relevant, score: evidence.score });
+    byQuery.set(candidate.queryId, values);
+  }
+
+  const perQuery: Record<string, { recall: number; ndcg: number }> = {};
+  for (const [queryId, values] of byQuery) {
+    values.sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
+    const relevantTotal = values.filter((value) => value.relevant).length;
+    const top = values.slice(0, k);
+    const relevantRetrieved = top.filter((value) => value.relevant).length;
+    const recall = relevantTotal === 0 ? 1 : relevantRetrieved / relevantTotal;
+    const dcg = top.reduce(
+      (sum, value, index) => sum + (value.relevant ? 1 / Math.log2(index + 2) : 0),
+      0,
+    );
+    const idealCount = Math.min(k, relevantTotal);
+    let idealDcg = 0;
+    for (let index = 0; index < idealCount; index++) idealDcg += 1 / Math.log2(index + 2);
+    perQuery[queryId] = { recall, ndcg: idealDcg === 0 ? 1 : dcg / idealDcg };
+  }
+  const queryMetrics = Object.values(perQuery);
+  return {
+    profileId: profile.id,
+    profileDigest: scoringProfileDigest(profile),
+    queries: queryMetrics.length,
+    recallAtK: mean(queryMetrics.map((item) => item.recall)),
+    ndcgAtK: mean(queryMetrics.map((item) => item.ndcg)),
+    missingSignalRatio: possibleSignals === 0 ? 0 : missing / possibleSignals,
+    perQuery,
+  };
+}
+
+export function compareScoringProfiles(
+  baseline: ScoringProfileEvaluation,
+  candidate: ScoringProfileEvaluation,
+  samples = 2_000,
+  seed = 20_260_824,
+): ScoringProfileComparison {
+  const queryIds = Object.keys(baseline.perQuery).filter((id) => candidate.perQuery[id]);
+  return {
+    candidate,
+    recallDifference: pairedBootstrap(
+      queryIds.map(
+        (id) => (candidate.perQuery[id]?.recall ?? 0) - (baseline.perQuery[id]?.recall ?? 0),
+      ),
+      samples,
+      seed,
+    ),
+    ndcgDifference: pairedBootstrap(
+      queryIds.map(
+        (id) => (candidate.perQuery[id]?.ndcg ?? 0) - (baseline.perQuery[id]?.ndcg ?? 0),
+      ),
+      samples,
+      seed + 1,
+    ),
+  };
+}
+
+export function selectProfileByValidation(
+  evaluations: readonly ScoringProfileEvaluation[],
+  baseline: ScoringProfileEvaluation,
+): ScoringProfileEvaluation | null {
+  return (
+    [...evaluations]
+      .filter((evaluation) => evaluation.recallAtK >= baseline.recallAtK - 0.01)
+      .sort(
+        (left, right) =>
+          right.ndcgAtK - left.ndcgAtK ||
+          right.recallAtK - left.recallAtK ||
+          left.profileDigest.localeCompare(right.profileDigest),
+      )[0] ?? null
+  );
+}
+
+interface ScoredCandidate {
+  readonly id: string;
+  readonly relevant: boolean;
+  readonly score: number;
+}
+
+function pairedBootstrap(
+  differences: readonly number[],
+  samples: number,
+  seed: number,
+): BootstrapInterval {
+  if (differences.length === 0) return { mean: 0, lower95: 0, upper95: 0 };
+  const random = mulberry32(seed);
+  const estimates: number[] = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < differences.length; index++) {
+      total += differences[Math.floor(random() * differences.length)] ?? 0;
+    }
+    estimates.push(total / differences.length);
+  }
+  estimates.sort((left, right) => left - right);
+  return {
+    mean: mean(differences),
+    lower95: percentile(estimates, 0.025),
+    upper95: percentile(estimates, 0.975),
+  };
+}
+
+function percentile(values: readonly number[], quantile: number): number {
+  const index = Math.min(values.length - 1, Math.max(0, Math.floor(quantile * values.length)));
+  return values[index] ?? 0;
+}
+
+function mean(values: readonly number[]): number {
+  return values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function stableHash(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}

--- a/docs/adr/0005-versioned-traversal-scoring.md
+++ b/docs/adr/0005-versioned-traversal-scoring.md
@@ -1,0 +1,60 @@
+# ADR 0005: Use versioned observation-based traversal scoring
+
+## Status
+
+Accepted
+
+## Context
+
+The bidirectional retriever previously received final-looking numbers from graph adapters:
+`confidence`, `queryRelevance`, `evidenceSupport`, and `score`. In production and benchmark
+adapters, many of those fields were constants. This made an unknown signal indistinguishable
+from a measured value and duplicated ranking policy across adapters.
+
+The old edge formula also applied `hopPenalty ** totalDepth` on every transition. A path therefore
+accumulated a triangular depth penalty rather than one penalty per edge.
+
+## Decision
+
+Adapters report raw observations:
+
+- provider rank and normalized retrieval observations for seeds;
+- deterministic, declared, extracted, or inferred structural provenance for edges;
+- query-match observations without fabricated defaults;
+- active, curated, derived, distinct-resource, conflict, and stale evidence counts;
+- evidence origin and freshness when known.
+
+`CalibratedTraversalScorePolicy` is the only module that converts these observations into traversal
+priority. Its parameters live in a validated, versioned `TraversalScoringProfile`. Each profile has
+a stable digest, and every selected evidence item includes its seed, edge, and evidence score
+breakdown. Missing values remain missing, use an explicit profile policy, and appear in the search
+trace.
+
+Transitions multiply factors in log space. Every transition factor must be in `[0, 1]`, so graph
+cycles cannot increase path priority. Hop decay is applied exactly once per traversed edge, with a
+separate KG-expansion factor.
+
+`BalancedTraversalScorePolicy` remains as a deprecated compatibility policy for existing callers
+that still provide legacy numeric fields. PostgreSQL runtime uses the observation-based profile.
+
+## Deployment
+
+Scoring profiles are immutable PostgreSQL deployments with staged, active, retired, and failed
+states. The organization runtime row points to active and optional shadow profile digests. The
+resolver caches the selected policy briefly, supports a full shadow traversal, and clears its cache
+on activation, shadow changes, and rollback.
+
+Schema changes are additive. Historical provenance remains `NULL`; it is never fabricated during
+migration. New ingestion preserves extraction confidence, extractor version, origin, observed time,
+and verified time when supplied.
+
+## Consequences
+
+- Production and benchmark graph adapters share the same seed fusion and scorer.
+- Changing a ranking prior requires a new profile version, evaluation artifact, and activation—not
+  scattered source edits.
+- A shadow profile costs a second graph traversal and must be enabled only during controlled
+  evaluation windows.
+- Scores are query-local priorities, not probabilities.
+- Legacy fields can be removed only after their usage reaches zero and rollback no longer depends
+  on them.

--- a/docs/adr/0006-query-adaptive-route-scoring.md
+++ b/docs/adr/0006-query-adaptive-route-scoring.md
@@ -1,0 +1,88 @@
+# ADR 0006: Adapt traversal authority from query-local route observations
+
+## Status
+
+Accepted as a route-suppression experiment; production activation rejected
+
+## Context
+
+ADR 0005 centralized traversal scoring, but its first `calibrated-v2` profile still applied the
+same route priors to every query and corpus. In the Medical regression run, broad
+`chunk → resource → chunk` traversal occupied 67.79% of the selected top ten. The adapter had
+already ordered those neighbors, but the scorer could not observe route fanout or query-local
+rank. A candidate could therefore receive full route authority merely because it was first in a
+weak or one-item list.
+
+Replacing those priors with one fitted global weight set would move the fixed-value problem rather
+than solve it. Dataset or organization names must also never be runtime scoring features.
+
+## Decision
+
+Keep the versioned observation-based base scorer and add a query-bound policy behind the same
+scoring interface. `AdaptiveRouteTraversalScorePolicy.bind(question)` classifies only coarse query
+intent and returns an explainable scorer for that retrieval.
+
+Graph adapters report two additional query-local observations for every bounded neighbor list:
+
+- returned and pre-cut candidate counts;
+- rank and, when honestly available, an adapter-normalized query score.
+
+For normal lookup/comparison traversal, route authority is gated by:
+
+```text
+log2(1 + returned) / log2(1 + candidates)
+× 1 / log2(rank + 1)
+× normalized query evidence
+```
+
+An unavailable normalized score is neutral rather than fabricated. Resource-to-chunk traversal for
+a summary query relaxes the fanout and absolute-match gates because broad coverage is the requested
+behavior. Non-chunk seeds with an observed normalized match are likewise gated by that observation.
+
+The formula has no dataset-specific threshold or fitted route weight. It changes per question and
+per neighbor list from observed selectivity, rank, and query evidence. The versioned base profile
+continues to own structural provenance, support, evidence, hop, and missing-signal policies; this
+ADR does not claim that every prior has become learned or parameter-free.
+
+Every selected result records the bound query intent, route name, fanout, rank, query evidence, and
+adaptive gate in its score breakdown. The benchmark records the policy digest and feature schema.
+
+## Evaluation decision
+
+`adaptive-route-v3` version 2 improved both recall and raw context precision on all 2,062 Medical
+and 2,010 Novel queries compared with `calibrated-v2`. Against the previous Medical bidirectional
+policy it improved Recall@10 from 0.70223 to 0.71435 and precision from 0.35470 to 0.36508.
+
+Production activation was initially deferred because Medical p95 retrieval latency was 17.30 ms
+versus 10.28 ms for the previous policy, above the rollout gate. The selected results also became
+91.86% direct on Medical and 98.11% direct on Novel, so this experiment validates route suppression
+but does not by itself prove an N-layer advantage over an equivalent direct-only hybrid retriever.
+
+The subsequent matched direct-only ablation disabled only graph expansion (`maxHops: 0`) while
+holding candidate generation, embeddings, seed fusion, and scoring fixed. Graph-minus-direct
+Recall@10 was -0.00097 on Medical (95% CI [-0.00679, 0.00485]) and -0.00100 on Novel
+([-0.00398, 0.00199]). Context precision decreased by 0.00902 on Medical and 0.00174 on Novel;
+both precision intervals excluded zero. The current graph-enabled configuration therefore fails
+the incremental-value gate and must not be activated.
+
+A second matched ablation repeated the comparison after weighted hybrid fusion and identical
+5,000-character source-window hydration. In that setting, graph traversal increased aggregate
+Recall@10 by 0.00582 on Medical (95% CI [0.00048, 0.01115]) and 0.00498 on Novel
+([0.00100, 0.00896]), but decreased precision by 0.00602 and 0.00277 respectively; both precision
+intervals excluded zero. The recall gain also failed to become a strict win on both deterministic
+holdouts. The source-hydrated direct control remains the default quality candidate, while graph
+traversal is limited to an explicit recall-first policy.
+
+## Consequences
+
+- Broad graph routes must earn authority from their observed selectivity and query evidence.
+- The same scoring implementation can behave differently across corpora without inspecting corpus
+  identity.
+- Adapters that cannot report an observation receive neutral treatment and remain compatible, but
+  gain less adaptation.
+- Query intent classification is intentionally small and auditable; improving it requires a new
+  policy version and paired evaluation.
+- Source hydration and hybrid fusion may be promoted independently of graph traversal; their
+  direct-only control produced the strongest overall retrieval scores in this evaluation.
+- Any redesigned graph route must show a positive paired increment over the matched direct-only
+  control before activation; production shadow latency profiling remains required.

--- a/docs/runbooks/scoring-profile-rollout.md
+++ b/docs/runbooks/scoring-profile-rollout.md
@@ -1,0 +1,87 @@
+# Scoring profile rollout runbook
+
+## Preconditions
+
+Before staging a profile, record its development, validation, and holdout results separately. The
+artifact must identify the profile digest, feature schema, corpus and candidate-pool digests, code
+commit, split IDs, and the exact evaluation command.
+
+Do not activate a profile if it violates any of these gates:
+
+- Evidence Recall@10 drops by more than 1 percentage point on any required dataset cell.
+- strict faithfulness or citation F1 has a statistically significant regression.
+- ACL/RLS or conflict-disclosure tests fail.
+- score-breakdown coverage is below 100%.
+- retrieval p95 rises by more than 10% in an isolated comparison.
+- visited or candidate budgets are exceeded.
+
+## Stage
+
+1. Validate the profile with `validateTraversalScoringProfile`.
+2. Call `PostgresScoringProfileRepository.stage(organizationId, profile, evaluationSummary)`.
+3. Save the returned digest with the evaluation report.
+4. Confirm `getActive()` still returns the previous profile.
+
+Staging is idempotent for the same profile content. Reusing the same profile ID and version with
+different content is rejected by the database uniqueness constraint; increment the version.
+Normal activation rejects a profile without an evaluation summary. `allowUnevaluated` is a
+break-glass option and its use must be recorded as an incident action.
+
+## Shadow
+
+1. Call `setShadow(organizationId, stagedDigest)`.
+2. Verify that active responses still report the active profile at `trace.scoring.profileDigest`.
+3. Collect `trace.scoring.shadow` overlap, normalized rank disagreement, latency, visited count, and
+   candidate count.
+4. Also monitor missing-signal counts, zero-evidence rate, conflict evidence rate, and ACL outcomes.
+5. Call `setShadow(organizationId, null)` when the evaluation window ends.
+
+Shadow mode runs an independent frontier and top-K inside the same read-only search session. It
+doubles graph work by design, so do not leave it enabled indefinitely.
+
+## Activate and canary
+
+Set the initial canary percentage before activation so a new profile never receives an accidental
+100% traffic window. Activation is atomic:
+
+```ts
+await scoringProfiles.setCanaryPercent(organizationId, 5);
+await scoringProfiles.activate(organizationId, stagedDigest);
+```
+
+Start with an internal organization, then set a stable subject-level cohort with
+`setCanaryPercent(organizationId, percent)`. Recommended checkpoints are 5%, 25%, 50%, and 100%.
+The resolver hashes organization and subject IDs, so the same subject remains in the same cohort.
+At each checkpoint compare retrieval quality,
+citation coverage, abstention, zero-evidence rate, p95 latency, and budget utilization against the
+previous profile.
+
+Activating the configured shadow profile clears the shadow pointer automatically.
+
+## Roll back
+
+Keep the previous active digest in the deployment record. Rollback is an atomic pointer and status
+change; no schema rollback or reindex is required:
+
+```ts
+await scoringProfiles.rollback(organizationId, previousDigest);
+```
+
+After rollback, confirm that new traces contain the previous digest and that the resolver cache was
+invalidated. Rollback resets the canary percentage to 100 so every subject receives the restored
+profile. Preserve the failed profile and its telemetry for analysis; do not edit its stored content.
+
+## Incident checks
+
+If retrieval quality changes unexpectedly, inspect in this order:
+
+1. active and shadow profile IDs, versions, and digests;
+2. seed provider counts and missing-signal counts;
+3. selected evidence score breakdowns and path lengths;
+4. conflict, stale, origin, and freshness observations;
+5. ACL-filtered support aggregates and RLS session organization;
+6. candidate, visited, hop, and time stop reasons;
+7. corpus, index, candidate-pool, and feature-schema digests in the benchmark artifact.
+
+Never repair an incident by editing constants in an adapter. Create a new profile version, evaluate
+it, and move it through stage, shadow, and activation.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,9 @@ export * from "./query/layered-context-collector.js";
 export * from "./query/layered-query-pipeline.js";
 export * from "./query/n-layer.js";
 export * from "./query/bidirectional-retriever.js";
+export * from "./query/adaptive-traversal-scoring.js";
+export * from "./query/traversal-scoring.js";
+export * from "./query/seed-fusion.js";
 export * from "./query/source-context-hydrator.js";
 export * from "./query/answer-validator.js";
 

--- a/packages/core/src/knowledge/domain.ts
+++ b/packages/core/src/knowledge/domain.ts
@@ -22,6 +22,14 @@ export type RecordStatus = "active" | "stale" | "purged";
 export type FactStatus = "active" | "inactive" | "conflict";
 export type EvidenceOrigin = "derived" | "curated";
 export type EntityScope = "resource" | "global";
+export type OntologyLinkOrigin = "manual" | "automatic" | "deterministic";
+
+export interface OntologyLinkRecord {
+  readonly ontologyNodeId: string;
+  readonly origin?: OntologyLinkOrigin;
+  readonly confidence?: number;
+  readonly createdAt?: string;
+}
 
 export interface ResourceRecord {
   readonly organizationId: OrganizationId;
@@ -32,6 +40,7 @@ export interface ResourceRecord {
   readonly contentObjectKey: string;
   readonly acl: AccessControlList;
   readonly ontologyNodeIds: readonly string[];
+  readonly ontologyLinks?: readonly OntologyLinkRecord[];
   readonly status: RecordStatus;
   readonly updatedAt: string;
 }
@@ -46,6 +55,7 @@ export interface ChunkRecord {
   readonly position: number;
   readonly acl: AccessControlList;
   readonly ontologyNodeIds: readonly string[];
+  readonly ontologyLinks?: readonly OntologyLinkRecord[];
   readonly status: RecordStatus;
 }
 
@@ -59,6 +69,10 @@ export interface ExtractedEntity extends EntityRef {
   readonly type?: string;
   readonly mentionChunkIds: readonly string[];
   readonly promotionEvidence?: "deterministic" | "manual" | "resolved";
+  readonly extractionConfidence?: number;
+  readonly extractorVersion?: string;
+  readonly origin?: EvidenceOrigin;
+  readonly observedAt?: string;
 }
 
 export interface EntityRecord extends EntityRef {
@@ -75,6 +89,10 @@ export interface EntityMentionRecord {
   readonly resourceId: string;
   readonly chunkId: string;
   readonly status: RecordStatus;
+  readonly extractionConfidence?: number;
+  readonly extractorVersion?: string;
+  readonly origin?: EvidenceOrigin;
+  readonly observedAt?: string;
 }
 
 export type FactObject =
@@ -88,6 +106,11 @@ export interface ExtractedFact {
   readonly object: FactObject;
   readonly evidenceChunkIds: readonly string[];
   readonly singleValue?: boolean;
+  readonly extractionConfidence?: number;
+  readonly extractorVersion?: string;
+  readonly origin?: EvidenceOrigin;
+  readonly observedAt?: string;
+  readonly verifiedAt?: string;
 }
 
 export interface FactRecord {
@@ -99,6 +122,11 @@ export interface FactRecord {
   readonly singleValue: boolean;
   readonly status: FactStatus;
   readonly updatedAt: string;
+  readonly extractionConfidence?: number;
+  readonly extractorVersion?: string;
+  readonly origin?: EvidenceOrigin;
+  readonly observedAt?: string;
+  readonly verifiedAt?: string;
 }
 
 export type FactEventType =
@@ -125,6 +153,9 @@ export interface EvidenceRecord {
   readonly acl: AccessControlList;
   readonly origin: EvidenceOrigin;
   readonly status: RecordStatus;
+  readonly confidence?: number;
+  readonly observedAt?: string;
+  readonly verifiedAt?: string;
 }
 
 export interface ResourceChunkSnapshot {
@@ -133,6 +164,7 @@ export interface ResourceChunkSnapshot {
   readonly text: string;
   readonly position: number;
   readonly ontologyNodeIds?: readonly string[];
+  readonly ontologyLinks?: readonly OntologyLinkRecord[];
   readonly acl?: AccessControlList;
 }
 
@@ -144,6 +176,7 @@ export interface ResourceSnapshot {
   readonly body: string;
   readonly acl: AccessControlList;
   readonly ontologyNodeIds?: readonly string[];
+  readonly ontologyLinks?: readonly OntologyLinkRecord[];
   readonly chunks: readonly ResourceChunkSnapshot[];
   readonly entities?: readonly ExtractedEntity[];
   readonly facts?: readonly ExtractedFact[];

--- a/packages/core/src/knowledge/sync-resource.ts
+++ b/packages/core/src/knowledge/sync-resource.ts
@@ -89,7 +89,11 @@ export class SyncResourceUseCase implements ResourceSyncUseCase {
           contentHash: snapshot.contentHash,
           contentObjectKey: objectKey,
           acl: snapshot.acl,
-          ontologyNodeIds: unique(snapshot.ontologyNodeIds ?? []),
+          ontologyNodeIds: unique([
+            ...(snapshot.ontologyNodeIds ?? []),
+            ...(snapshot.ontologyLinks ?? []).map((link) => link.ontologyNodeId),
+          ]),
+          ontologyLinks: snapshot.ontologyLinks,
           status: "active",
           updatedAt: now,
         });
@@ -107,7 +111,11 @@ export class SyncResourceUseCase implements ResourceSyncUseCase {
             contentObjectKey: objectKey,
             position: chunk.position,
             acl: chunk.acl ?? snapshot.acl,
-            ontologyNodeIds: unique(chunk.ontologyNodeIds ?? []),
+            ontologyNodeIds: unique([
+              ...(chunk.ontologyNodeIds ?? []),
+              ...(chunk.ontologyLinks ?? []).map((link) => link.ontologyNodeId),
+            ]),
+            ontologyLinks: chunk.ontologyLinks,
             status: "active",
           });
           await unitOfWork.saveEvidence({
@@ -118,10 +126,11 @@ export class SyncResourceUseCase implements ResourceSyncUseCase {
             acl: chunk.acl ?? snapshot.acl,
             origin: "derived",
             status: "active",
+            observedAt: now,
           });
         }
 
-        await this.replaceEntityMentions(unitOfWork, snapshot, resourceId, chunkIds);
+        await this.replaceEntityMentions(unitOfWork, snapshot, resourceId, chunkIds, now);
 
         for (const extracted of snapshot.facts ?? []) {
           if (extracted.evidenceChunkIds.length === 0) {
@@ -146,6 +155,11 @@ export class SyncResourceUseCase implements ResourceSyncUseCase {
             singleValue: extracted.singleValue ?? false,
             status: previous?.status ?? "active",
             updatedAt: now,
+            extractionConfidence: extracted.extractionConfidence,
+            extractorVersion: extracted.extractorVersion,
+            origin: extracted.origin ?? "derived",
+            observedAt: extracted.observedAt ?? now,
+            verifiedAt: extracted.verifiedAt,
           };
           await unitOfWork.saveFact(next);
           if (!previous) {
@@ -173,8 +187,11 @@ export class SyncResourceUseCase implements ResourceSyncUseCase {
               resourceId,
               chunkId,
               acl: snapshot.chunks.find((chunk) => chunk.id === sourceChunkId)?.acl ?? snapshot.acl,
-              origin: "derived",
+              origin: extracted.origin ?? "derived",
               status: "active",
+              confidence: extracted.extractionConfidence,
+              observedAt: extracted.observedAt ?? now,
+              verifiedAt: extracted.verifiedAt,
             };
             await unitOfWork.saveEvidence(evidence);
           }
@@ -285,6 +302,7 @@ export class SyncResourceUseCase implements ResourceSyncUseCase {
     snapshot: ResourceSnapshot,
     resourceId: string,
     chunkIds: ReadonlyMap<string, string>,
+    now: string,
   ): Promise<void> {
     for (const extracted of snapshot.entities ?? []) {
       const mayBeGlobal = extracted.scope === "global" && extracted.promotionEvidence !== undefined;
@@ -314,6 +332,10 @@ export class SyncResourceUseCase implements ResourceSyncUseCase {
           resourceId,
           chunkId,
           status: "active",
+          extractionConfidence: extracted.extractionConfidence,
+          extractorVersion: extracted.extractorVersion,
+          origin: extracted.origin ?? "derived",
+          observedAt: extracted.observedAt ?? now,
         });
       }
     }

--- a/packages/core/src/query/adaptive-traversal-scoring.ts
+++ b/packages/core/src/query/adaptive-traversal-scoring.ts
@@ -1,0 +1,198 @@
+import { createHash } from "node:crypto";
+import {
+  CalibratedTraversalScorePolicy,
+  DEFAULT_CALIBRATED_SCORING_PROFILE,
+  type EdgeScoreInput,
+  type EvidenceScoreInput,
+  type ExplainableTraversalScorePolicy,
+  type QueryAdaptiveTraversalScorePolicy,
+  type QueryMatchObservation,
+  type RankedRetrievalObservation,
+  type ScoreComputation,
+  type ScorePolicyDescriptor,
+  type SeedScoreInput,
+  type TraversalScoringProfile,
+} from "./traversal-scoring.js";
+
+export type AdaptiveQueryIntent = "summary" | "comparison" | "lookup";
+
+const ADAPTIVE_ROUTE_ALGORITHM_VERSION = "adaptive-route-gate-v2";
+
+/**
+ * Query-local route adaptation behind the existing scoring interface.
+ *
+ * It never branches on a dataset or organization name. Broad neighbor lists
+ * receive less authority than selective lists, lower list ranks decay by
+ * reciprocal rank, and summary questions may intentionally traverse a broad
+ * resource because broad coverage is the requested behavior.
+ */
+export class AdaptiveRouteTraversalScorePolicy implements QueryAdaptiveTraversalScorePolicy {
+  readonly queryAdaptive = true as const;
+  readonly descriptor: ScorePolicyDescriptor;
+  private readonly base: CalibratedTraversalScorePolicy;
+
+  constructor(profile: TraversalScoringProfile = DEFAULT_CALIBRATED_SCORING_PROFILE) {
+    this.base = new CalibratedTraversalScorePolicy(profile);
+    const profileDigest = `sha256:${createHash("sha256")
+      .update(ADAPTIVE_ROUTE_ALGORITHM_VERSION)
+      .update("\0")
+      .update(this.base.descriptor.profileDigest)
+      .digest("hex")}`;
+    this.descriptor = {
+      profileId: "adaptive-route-v3",
+      profileVersion: 2,
+      profileDigest,
+      featureSchemaVersion: "n-layer-adaptive-routing-v1",
+    };
+  }
+
+  bind(question: string): ExplainableTraversalScorePolicy {
+    return new BoundAdaptiveRoutePolicy(this.base, this.descriptor, classifyIntent(question));
+  }
+}
+
+class BoundAdaptiveRoutePolicy implements ExplainableTraversalScorePolicy {
+  readonly explainable = true as const;
+
+  constructor(
+    private readonly base: CalibratedTraversalScorePolicy,
+    readonly descriptor: ScorePolicyDescriptor,
+    private readonly intent: AdaptiveQueryIntent,
+  ) {}
+
+  seedScore(input: SeedScoreInput): ScoreComputation {
+    const base = this.base.seedScore(input);
+    const normalizedMatch = bestNormalizedMatch(input.observations?.query);
+    const semanticGate =
+      input.nodeKind !== "chunk" && normalizedMatch !== undefined ? normalizedMatch : 1;
+    return adaptComputation(
+      base,
+      semanticGate,
+      { adaptiveSeedGate: semanticGate },
+      {
+        nodeKind: input.nodeKind ?? "unknown",
+        providers: (input.observations?.providers ?? []).join(","),
+        providerCount: input.observations?.providers?.length ?? 0,
+        queryIntent: this.intent,
+      },
+    );
+  }
+
+  edgeScore(parentScore: number, input: EdgeScoreInput, hop: number): ScoreComputation {
+    const base = this.base.edgeScore(parentScore, input, hop);
+    const fanout = input.observations?.fanout;
+    if (!fanout) {
+      return adaptComputation(
+        base,
+        1,
+        { adaptiveRouteGate: 1 },
+        { route: routeName(input), queryIntent: this.intent },
+      );
+    }
+
+    const selectivity = fanoutSelectivity(fanout.returnedCount, fanout.candidateCount);
+    const queryRank = bestReciprocalRank(input.observations?.query) ?? 1;
+    const queryEvidence = bestNormalizedMatch(input.observations?.query) ?? 1;
+    const summaryCoverage =
+      this.intent === "summary" && input.fromKind === "resource" && input.toKind === "chunk";
+    // Rank only says which candidate won within this route. An absolute,
+    // adapter-normalized query signal prevents a one-item or uniformly weak
+    // route from receiving full authority merely because its best item is #1.
+    // Missing native scores remain neutral so adapters can adopt the feature
+    // incrementally without inventing pseudo-confidence.
+    const routeGate = summaryCoverage ? queryRank : selectivity * queryRank * queryEvidence;
+    return adaptComputation(
+      base,
+      routeGate,
+      {
+        adaptiveRouteGate: routeGate,
+        fanoutSelectivity: selectivity,
+        routeQueryRank: queryRank,
+        routeQueryEvidence: queryEvidence,
+        summaryCoverage: summaryCoverage ? 1 : 0,
+      },
+      {
+        route: routeName(input),
+        queryIntent: this.intent,
+        fanoutReturnedCount: positiveInteger(fanout.returnedCount),
+        fanoutCandidateCount: positiveInteger(fanout.candidateCount),
+      },
+    );
+  }
+
+  evidenceScore(pathScore: number, input: EvidenceScoreInput): ScoreComputation {
+    return this.base.evidenceScore(pathScore, input);
+  }
+}
+
+function adaptComputation(
+  base: ScoreComputation,
+  gate: number,
+  factors: Readonly<Record<string, number>>,
+  observations: Readonly<Record<string, number | boolean | string>>,
+): ScoreComputation {
+  return {
+    ...base,
+    score: clamp(base.score * gate),
+    factors: { ...base.factors, ...factors },
+    observations: { ...base.observations, ...observations },
+  };
+}
+
+function fanoutSelectivity(returnedCount: number, candidateCount: number): number {
+  const returned = Math.min(positiveInteger(returnedCount), positiveInteger(candidateCount));
+  const candidates = Math.max(returned, positiveInteger(candidateCount));
+  return Math.log2(1 + returned) / Math.log2(1 + candidates);
+}
+
+function bestReciprocalRank(query: QueryMatchObservation | undefined): number | undefined {
+  if (query?.exactMatch || query?.aliasMatch) return 1;
+  const ranks = [query?.lexical, query?.vector]
+    .filter((value): value is RankedRetrievalObservation => value !== undefined)
+    .map((value) => 1 / Math.log2(positiveInteger(value.rank) + 1));
+  return ranks.length === 0 ? undefined : Math.max(...ranks);
+}
+
+function bestNormalizedMatch(query: QueryMatchObservation | undefined): number | undefined {
+  if (query?.exactMatch || query?.aliasMatch) return 1;
+  const values = [
+    query?.lexical?.normalizedScore,
+    query?.vector?.normalizedScore,
+    query?.rerankerScore,
+  ].filter((value): value is number => value !== undefined && Number.isFinite(value));
+  return values.length === 0 ? undefined : clamp(Math.max(...values));
+}
+
+function classifyIntent(question: string): AdaptiveQueryIntent {
+  const normalized = question.toLocaleLowerCase();
+  if (
+    /\b(summary|summarize|overview|main themes?|comprehensive account|outline)\b/.test(
+      normalized,
+    ) ||
+    /(요약|개요|전체 내용|핵심 내용)/.test(normalized)
+  ) {
+    return "summary";
+  }
+  if (
+    /\b(compare|comparison|contrast|difference|versus|vs\.?|relationship between)\b/.test(
+      normalized,
+    ) ||
+    /(비교|차이|관계)/.test(normalized)
+  ) {
+    return "comparison";
+  }
+  return "lookup";
+}
+
+function routeName(input: EdgeScoreInput): string {
+  return `${input.fromKind}:${input.operation}:${input.toKind}`;
+}
+
+function positiveInteger(value: number): number {
+  return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 1;
+}
+
+function clamp(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}

--- a/packages/core/src/query/bidirectional-retriever.ts
+++ b/packages/core/src/query/bidirectional-retriever.ts
@@ -1,4 +1,14 @@
 import type { Principal } from "../knowledge/domain.js";
+import type {
+  EvidenceHitObservations,
+  ExplainableTraversalScorePolicy,
+  QueryAdaptiveTraversalScorePolicy,
+  ScoreComputation,
+  ScorePolicyDescriptor,
+  SearchEdgeObservations,
+  SearchSeedObservations,
+  TraversalScoreBreakdown,
+} from "./traversal-scoring.js";
 
 export type SearchNodeKind = "ontology" | "resource" | "chunk" | "entity" | "fact";
 export type SearchOperation = "lift" | "expand" | "ground";
@@ -10,16 +20,22 @@ export interface SearchNode {
 
 export interface SearchSeed {
   readonly node: SearchNode;
-  readonly score: number;
+  /** @deprecated Prefer raw `observations`; retained for legacy-v1 compatibility. */
+  readonly score?: number;
+  readonly observations?: SearchSeedObservations;
 }
 
 export interface SearchEdge {
   readonly from: SearchNode;
   readonly to: SearchNode;
   readonly operation: SearchOperation;
-  readonly confidence: number;
-  readonly queryRelevance: number;
-  readonly evidenceSupport: number;
+  /** @deprecated Prefer `observations.structural`. */
+  readonly confidence?: number;
+  /** @deprecated Prefer `observations.query`. */
+  readonly queryRelevance?: number;
+  /** @deprecated Prefer `observations.support`. */
+  readonly evidenceSupport?: number;
+  readonly observations?: SearchEdgeObservations;
 }
 
 export interface EvidenceHit {
@@ -27,14 +43,17 @@ export interface EvidenceHit {
   readonly chunkId: string;
   readonly resourceId: string;
   readonly text: string;
-  readonly score: number;
+  /** @deprecated Prefer raw `observations`; retained for legacy-v1 compatibility. */
+  readonly score?: number;
   readonly factKey?: string;
   readonly factStatus?: "active" | "conflict";
+  readonly observations?: EvidenceHitObservations;
 }
 
 export interface RankedEvidenceHit extends EvidenceHit {
   readonly score: number;
   readonly path: readonly SearchEdge[];
+  readonly scoreBreakdown?: TraversalScoreBreakdown;
 }
 
 /**
@@ -96,6 +115,31 @@ export interface SearchTrace {
   readonly candidates: number;
   readonly elapsedMs: number;
   readonly stoppedBy: SearchStopReason;
+  readonly averageSelectedPathLength: number;
+  readonly maxSelectedPathLength: number;
+  readonly seedProviderCounts: Readonly<Record<string, number>>;
+  readonly scoring: ScorePolicyDescriptor & {
+    readonly missingSignals: readonly string[];
+    readonly missingSignalCounts: Readonly<Record<string, number>>;
+    readonly routing?: AdaptiveRoutingTrace;
+    readonly shadow?: SearchShadowTrace;
+  };
+}
+
+export interface AdaptiveRoutingTrace {
+  readonly selectedRouteCounts: Readonly<Record<string, number>>;
+  readonly averageRouteGate: number;
+  readonly queryIntent?: string;
+}
+
+export interface SearchShadowTrace extends ScorePolicyDescriptor {
+  readonly status: "completed" | "failed";
+  readonly topKOverlapRatio?: number;
+  readonly normalizedRankDisagreement?: number;
+  readonly visited?: number;
+  readonly candidates?: number;
+  readonly elapsedMs?: number;
+  readonly errorName?: string;
 }
 
 export interface BidirectionalRetrievalInput {
@@ -115,23 +159,35 @@ export interface TraversalScorePolicy {
   evidenceScore(pathScore: number, evidence: EvidenceHit): number;
 }
 
+type BoundTraversalScorePolicy = TraversalScorePolicy | ExplainableTraversalScorePolicy;
+
+export type AnyTraversalScorePolicy = BoundTraversalScorePolicy | QueryAdaptiveTraversalScorePolicy;
+
+export interface TraversalScorePolicyResolver {
+  resolve(principal: Principal): Promise<AnyTraversalScorePolicy>;
+  resolveShadow?(principal: Principal): Promise<AnyTraversalScorePolicy | null>;
+}
+
+/** @deprecated Use a versioned observation-based `CalibratedTraversalScorePolicy`. */
 export class BalancedTraversalScorePolicy implements TraversalScorePolicy {
   constructor(private readonly hopPenalty = 0.92) {}
 
   seedScore(seed: SearchSeed): number {
-    return clampScore(seed.score);
+    return clampScore(seed.score ?? 0);
   }
 
   edgeScore(parentScore: number, edge: SearchEdge, hop: number): number {
     const signals =
-      0.5 + 0.3 * clampScore(edge.queryRelevance) + 0.2 * clampScore(edge.evidenceSupport);
+      0.5 +
+      0.3 * clampScore(edge.queryRelevance ?? 0) +
+      0.2 * clampScore(edge.evidenceSupport ?? 0);
     return (
-      parentScore * clampScore(edge.confidence) * signals * this.hopPenalty ** Math.max(1, hop)
+      parentScore * clampScore(edge.confidence ?? 0) * signals * this.hopPenalty ** Math.max(1, hop)
     );
   }
 
   evidenceScore(pathScore: number, evidence: EvidenceHit): number {
-    return pathScore * clampScore(evidence.score);
+    return pathScore * clampScore(evidence.score ?? 0);
   }
 }
 
@@ -141,7 +197,16 @@ interface FrontierCandidate {
   readonly hops: number;
   readonly kgHops: number;
   readonly path: readonly SearchEdge[];
+  readonly seedComputation: ScoreComputation;
+  readonly edgeComputations: readonly ScoreComputation[];
 }
+
+const LEGACY_SCORE_DESCRIPTOR: ScorePolicyDescriptor = {
+  profileId: "legacy-v1",
+  profileVersion: 1,
+  profileDigest: "builtin:legacy-v1",
+  featureSchemaVersion: "legacy-score-fields-v1",
+};
 
 const DEFAULT_SEARCH_BUDGET: SearchBudget = {
   maxHops: 8,
@@ -156,13 +221,30 @@ const DEFAULT_SEARCH_BUDGET: SearchBudget = {
 export class BidirectionalNLayerRetriever {
   constructor(
     private readonly graph: SearchGraphPort,
-    private readonly scorePolicy: TraversalScorePolicy = new BalancedTraversalScorePolicy(),
+    private readonly scorePolicySource:
+      | AnyTraversalScorePolicy
+      | TraversalScorePolicyResolver = new BalancedTraversalScorePolicy(),
     private readonly now: () => number = () => performance.now(),
   ) {}
 
   async retrieve(input: BidirectionalRetrievalInput): Promise<BidirectionalRetrievalResult> {
     const budget = { ...DEFAULT_SEARCH_BUDGET, ...input.budget };
     const startedAt = this.now();
+    const resolvedScorePolicy = isScorePolicyResolver(this.scorePolicySource)
+      ? await this.scorePolicySource.resolve(input.principal)
+      : this.scorePolicySource;
+    const scorePolicy = bindQueryPolicy(resolvedScorePolicy, input.question);
+    let shadowPolicy: BoundTraversalScorePolicy | null = null;
+    let shadowResolutionError: unknown;
+    if (isScorePolicyResolver(this.scorePolicySource)) {
+      try {
+        const resolvedShadow =
+          (await this.scorePolicySource.resolveShadow?.(input.principal)) ?? null;
+        shadowPolicy = resolvedShadow ? bindQueryPolicy(resolvedShadow, input.question) : null;
+      } catch (error) {
+        shadowResolutionError = error;
+      }
+    }
     // One session for the whole traversal, so adapters can share a single
     // connection/transaction instead of opening one per visited node.
     const session = await this.graph.openSession?.(input.principal);
@@ -170,9 +252,52 @@ export class BidirectionalNLayerRetriever {
       | { readonly ok: true; readonly result: BidirectionalRetrievalResult }
       | { readonly ok: false; readonly error: unknown };
     try {
+      const result = await this.traverse(input, budget, startedAt, session, scorePolicy);
+      let shadow: SearchShadowTrace | undefined =
+        shadowResolutionError === undefined
+          ? undefined
+          : {
+              profileId: "unresolved-shadow",
+              profileVersion: 0,
+              profileDigest: "unresolved",
+              featureSchemaVersion: "unresolved",
+              status: "failed",
+              errorName:
+                shadowResolutionError instanceof Error
+                  ? shadowResolutionError.name
+                  : "UnknownError",
+            };
+      if (shadowPolicy) {
+        const shadowStartedAt = this.now();
+        try {
+          const shadowResult = await this.traverse(
+            input,
+            budget,
+            shadowStartedAt,
+            session,
+            shadowPolicy,
+          );
+          shadow = compareShadowResults(result, shadowResult);
+        } catch (error) {
+          shadow = {
+            ...scoreDescriptor(shadowPolicy),
+            status: "failed",
+            errorName: error instanceof Error ? error.name : "UnknownError",
+          };
+        }
+      }
       traversal = {
         ok: true,
-        result: await this.traverse(input, budget, startedAt, session),
+        result:
+          shadow === undefined
+            ? result
+            : {
+                ...result,
+                trace: {
+                  ...result.trace,
+                  scoring: { ...result.trace.scoring, shadow },
+                },
+              },
       };
     } catch (error) {
       traversal = { ok: false, error };
@@ -205,11 +330,13 @@ export class BidirectionalNLayerRetriever {
     budget: SearchBudget,
     startedAt: number,
     session: SearchGraphSession | undefined,
+    scorePolicy: BoundTraversalScorePolicy,
   ): Promise<BidirectionalRetrievalResult> {
     const frontier = new MaxPriorityQueue<FrontierCandidate>((candidate) => candidate.score);
     const bestScores = new Map<string, number>();
     const evidenceById = new Map<string, RankedEvidenceHit>();
     const evidenceScoresByNode = new Map<string, number>();
+    const missingSignalCounts = new Map<string, number>();
     let candidateCount = 0;
     let visited = 0;
     let stoppedBy: SearchStopReason = "frontier_exhausted";
@@ -219,16 +346,27 @@ export class BidirectionalNLayerRetriever {
       node: SearchNode,
       pathScore: number,
       path: readonly SearchEdge[],
+      seedComputation: ScoreComputation,
+      edgeComputations: readonly ScoreComputation[],
     ): Promise<void> => {
       const nodeKey = searchNodeKey(node);
       if (pathScore <= (evidenceScoresByNode.get(nodeKey) ?? Number.NEGATIVE_INFINITY)) return;
       evidenceScoresByNode.set(nodeKey, pathScore);
       const hits = await this.graph.evidence(node, input.principal, session);
       for (const hit of hits) {
+        const evidenceComputation = this.computeEvidenceScore(scorePolicy, pathScore, hit);
+        recordMissingSignals(missingSignalCounts, evidenceComputation.missingSignals);
         const ranked: RankedEvidenceHit = {
           ...hit,
-          score: this.scorePolicy.evidenceScore(pathScore, hit),
+          score: evidenceComputation.score,
           path,
+          scoreBreakdown: {
+            ...this.scoreDescriptor(scorePolicy),
+            seed: seedComputation,
+            edges: edgeComputations,
+            evidence: evidenceComputation,
+            finalScore: evidenceComputation.score,
+          },
         };
         const previous = evidenceById.get(hit.evidenceId);
         if (!previous || ranked.score > previous.score) evidenceById.set(hit.evidenceId, ranked);
@@ -246,27 +384,46 @@ export class BidirectionalNLayerRetriever {
           candidates: candidateCount,
           elapsedMs: this.now() - startedAt,
           stoppedBy: "time_budget",
+          averageSelectedPathLength: 0,
+          maxSelectedPathLength: 0,
+          seedProviderCounts: {},
+          scoring: {
+            ...this.scoreDescriptor(scorePolicy),
+            missingSignals: [],
+            missingSignalCounts: {},
+          },
         },
       };
     }
 
     const seeds = await this.graph.seed(input.question, input.principal, session);
+    const seedProviderCounts = countSeedProviders(seeds);
     for (const seed of seeds) {
       if (this.now() - startedAt >= budget.timeBudgetMs) {
         stoppedBy = "time_budget";
         break;
       }
-      const score = this.scorePolicy.seedScore(seed);
+      const seedComputation = this.computeSeedScore(scorePolicy, seed);
+      recordMissingSignals(missingSignalCounts, seedComputation.missingSignals);
+      const score = seedComputation.score;
       if (score < budget.minScore || candidateCount >= budget.maxCandidates) continue;
       const nodeKey = searchNodeKey(seed.node);
       if (score <= (bestScores.get(nodeKey) ?? Number.NEGATIVE_INFINITY)) continue;
       bestScores.set(nodeKey, score);
-      frontier.push({ node: seed.node, score, hops: 0, kgHops: 0, path: [] });
+      frontier.push({
+        node: seed.node,
+        score,
+        hops: 0,
+        kgHops: 0,
+        path: [],
+        seedComputation,
+        edgeComputations: [],
+      });
       candidateCount++;
       // A direct seed is already a successful retrieval candidate. Collect its
       // evidence before graph expansion so a high-fanout seed cannot exhaust
       // the candidate budget and starve lower-ranked direct hits.
-      await collectEvidence(seed.node, score, []);
+      await collectEvidence(seed.node, score, [], seedComputation, []);
       if (this.now() - startedAt >= budget.timeBudgetMs) {
         stoppedBy = "time_budget";
         break;
@@ -289,7 +446,13 @@ export class BidirectionalNLayerRetriever {
       if (current.score < (bestScores.get(currentKey) ?? Number.NEGATIVE_INFINITY)) continue;
       visited++;
 
-      await collectEvidence(current.node, current.score, current.path);
+      await collectEvidence(
+        current.node,
+        current.score,
+        current.path,
+        current.seedComputation,
+        current.edgeComputations,
+      );
 
       if (current.hops >= budget.maxHops || candidateBudgetReached) continue;
       const neighbors = await this.graph.neighbors(
@@ -307,7 +470,9 @@ export class BidirectionalNLayerRetriever {
         const kgHops = current.kgHops + (isKgExpansion(edge) ? 1 : 0);
         if (kgHops > budget.maxKgHops) continue;
         const hops = current.hops + 1;
-        const score = this.scorePolicy.edgeScore(current.score, edge, hops);
+        const edgeComputation = this.computeEdgeScore(scorePolicy, current.score, edge, hops);
+        recordMissingSignals(missingSignalCounts, edgeComputation.missingSignals);
+        const score = edgeComputation.score;
         if (score < budget.minScore) continue;
         const nextKey = searchNodeKey(edge.to);
         if (score <= (bestScores.get(nextKey) ?? Number.NEGATIVE_INFINITY)) continue;
@@ -318,23 +483,242 @@ export class BidirectionalNLayerRetriever {
           hops,
           kgHops,
           path: [...current.path, edge],
+          seedComputation: current.seedComputation,
+          edgeComputations: [...current.edgeComputations, edgeComputation],
         });
         candidateCount++;
       }
     }
 
+    const evidence = Array.from(evidenceById.values())
+      .sort((left, right) => right.score - left.score)
+      .slice(0, budget.topK);
+    const pathLengths = evidence.map((hit) => hit.path.length);
+    const routing = summarizeAdaptiveRouting(evidence);
     return {
-      evidence: Array.from(evidenceById.values())
-        .sort((left, right) => right.score - left.score)
-        .slice(0, budget.topK),
+      evidence,
       trace: {
         visited,
         candidates: candidateCount,
         elapsedMs: this.now() - startedAt,
         stoppedBy,
+        averageSelectedPathLength:
+          pathLengths.length === 0
+            ? 0
+            : pathLengths.reduce((sum, length) => sum + length, 0) / pathLengths.length,
+        maxSelectedPathLength: pathLengths.length === 0 ? 0 : Math.max(...pathLengths),
+        seedProviderCounts,
+        scoring: {
+          ...this.scoreDescriptor(scorePolicy),
+          missingSignals: Array.from(missingSignalCounts.keys()).sort(),
+          missingSignalCounts: Object.fromEntries(
+            Array.from(missingSignalCounts.entries()).sort(([left], [right]) =>
+              left.localeCompare(right),
+            ),
+          ),
+          ...(routing === undefined ? {} : { routing }),
+        },
       },
     };
   }
+
+  private computeSeedScore(
+    scorePolicy: BoundTraversalScorePolicy,
+    seed: SearchSeed,
+  ): ScoreComputation {
+    if (isExplainablePolicy(scorePolicy)) {
+      return scorePolicy.seedScore({
+        legacyScore: seed.score,
+        observations: seed.observations,
+        nodeKind: seed.node.kind,
+      });
+    }
+    const score = clampScore(scorePolicy.seedScore(seed));
+    return legacyComputation("seed", score, { legacySeedScore: score });
+  }
+
+  private computeEdgeScore(
+    scorePolicy: BoundTraversalScorePolicy,
+    parentScore: number,
+    edge: SearchEdge,
+    hop: number,
+  ): ScoreComputation {
+    if (isExplainablePolicy(scorePolicy)) {
+      return scorePolicy.edgeScore(
+        parentScore,
+        {
+          operation: edge.operation,
+          fromKind: edge.from.kind,
+          toKind: edge.to.kind,
+          legacyConfidence: edge.confidence,
+          legacyQueryRelevance: edge.queryRelevance,
+          legacyEvidenceSupport: edge.evidenceSupport,
+          observations: edge.observations,
+        },
+        hop,
+      );
+    }
+    const score = clampScore(scorePolicy.edgeScore(parentScore, edge, hop));
+    return legacyComputation("edge", score, { legacyEdgeScore: score }, parentScore);
+  }
+
+  private computeEvidenceScore(
+    scorePolicy: BoundTraversalScorePolicy,
+    pathScore: number,
+    evidence: EvidenceHit,
+  ): ScoreComputation {
+    if (isExplainablePolicy(scorePolicy)) {
+      return scorePolicy.evidenceScore(pathScore, {
+        legacyScore: evidence.score,
+        factStatus: evidence.factStatus,
+        observations: evidence.observations,
+      });
+    }
+    const score = clampScore(scorePolicy.evidenceScore(pathScore, evidence));
+    return legacyComputation("evidence", score, { legacyEvidenceScore: score }, pathScore);
+  }
+
+  private scoreDescriptor(scorePolicy: BoundTraversalScorePolicy): ScorePolicyDescriptor {
+    return scoreDescriptor(scorePolicy);
+  }
+}
+
+function scoreDescriptor(scorePolicy: BoundTraversalScorePolicy): ScorePolicyDescriptor {
+  return isExplainablePolicy(scorePolicy) ? scorePolicy.descriptor : LEGACY_SCORE_DESCRIPTOR;
+}
+
+function compareShadowResults(
+  active: BidirectionalRetrievalResult,
+  shadow: BidirectionalRetrievalResult,
+): SearchShadowTrace {
+  const activeIds = active.evidence.map((hit) => hit.evidenceId);
+  const shadowIds = shadow.evidence.map((hit) => hit.evidenceId);
+  const denominator = Math.max(1, activeIds.length, shadowIds.length);
+  const shadowSet = new Set(shadowIds);
+  const overlap = activeIds.filter((id) => shadowSet.has(id)).length / denominator;
+  const allIds = Array.from(new Set([...activeIds, ...shadowIds]));
+  const activeRanks = new Map(activeIds.map((id, index) => [id, index]));
+  const shadowRanks = new Map(shadowIds.map((id, index) => [id, index]));
+  const disagreement =
+    allIds.length === 0
+      ? 0
+      : allIds.reduce(
+          (sum, id) =>
+            sum +
+            Math.abs((activeRanks.get(id) ?? denominator) - (shadowRanks.get(id) ?? denominator)) /
+              denominator,
+          0,
+        ) / allIds.length;
+  return {
+    profileId: shadow.trace.scoring.profileId,
+    profileVersion: shadow.trace.scoring.profileVersion,
+    profileDigest: shadow.trace.scoring.profileDigest,
+    featureSchemaVersion: shadow.trace.scoring.featureSchemaVersion,
+    status: "completed",
+    topKOverlapRatio: overlap,
+    normalizedRankDisagreement: disagreement,
+    visited: shadow.trace.visited,
+    candidates: shadow.trace.candidates,
+    elapsedMs: shadow.trace.elapsedMs,
+  };
+}
+
+function recordMissingSignals(counts: Map<string, number>, signals: readonly string[]): void {
+  for (const signal of signals) counts.set(signal, (counts.get(signal) ?? 0) + 1);
+}
+
+function countSeedProviders(seeds: readonly SearchSeed[]): Readonly<Record<string, number>> {
+  const counts = new Map<string, number>();
+  for (const seed of seeds) {
+    for (const provider of seed.observations?.providers ?? ["unspecified"]) {
+      counts.set(provider, (counts.get(provider) ?? 0) + 1);
+    }
+  }
+  return Object.fromEntries(
+    Array.from(counts.entries()).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function bindQueryPolicy(
+  policy: AnyTraversalScorePolicy,
+  question: string,
+): BoundTraversalScorePolicy {
+  return isQueryAdaptivePolicy(policy) ? policy.bind(question) : policy;
+}
+
+function summarizeAdaptiveRouting(
+  evidence: readonly RankedEvidenceHit[],
+): AdaptiveRoutingTrace | undefined {
+  const routeCounts = new Map<string, number>();
+  const gates: number[] = [];
+  let queryIntent: string | undefined;
+  for (const hit of evidence) {
+    const route = evidenceRoute(hit);
+    routeCounts.set(route, (routeCounts.get(route) ?? 0) + 1);
+    const breakdown = hit.scoreBreakdown;
+    if (!breakdown) continue;
+    if (queryIntent === undefined) {
+      const observed = breakdown.seed.observations.queryIntent;
+      if (typeof observed === "string") queryIntent = observed;
+    }
+    for (const edge of breakdown.edges) {
+      const gate = edge.factors.adaptiveRouteGate;
+      if (gate !== undefined) gates.push(gate);
+    }
+  }
+  if (gates.length === 0 && queryIntent === undefined) return undefined;
+  return {
+    selectedRouteCounts: Object.fromEntries(
+      Array.from(routeCounts.entries()).sort(([left], [right]) => left.localeCompare(right)),
+    ),
+    averageRouteGate:
+      gates.length === 0 ? 1 : gates.reduce((sum, value) => sum + value, 0) / gates.length,
+    ...(queryIntent === undefined ? {} : { queryIntent }),
+  };
+}
+
+function evidenceRoute(hit: RankedEvidenceHit): string {
+  if (hit.path.length === 0) return "direct";
+  const kinds = new Set(hit.path.flatMap((edge) => [edge.from.kind, edge.to.kind]));
+  if (kinds.has("fact")) return "fact";
+  if (kinds.has("entity")) return "entity";
+  if (kinds.has("ontology")) return "ontology";
+  if (kinds.has("resource")) return "resource";
+  return "other";
+}
+
+function isExplainablePolicy(
+  policy: BoundTraversalScorePolicy,
+): policy is ExplainableTraversalScorePolicy {
+  return "explainable" in policy && policy.explainable === true;
+}
+
+function isQueryAdaptivePolicy(
+  policy: AnyTraversalScorePolicy,
+): policy is QueryAdaptiveTraversalScorePolicy {
+  return "queryAdaptive" in policy && policy.queryAdaptive === true;
+}
+
+function isScorePolicyResolver(
+  source: AnyTraversalScorePolicy | TraversalScorePolicyResolver,
+): source is TraversalScorePolicyResolver {
+  return "resolve" in source;
+}
+
+function legacyComputation(
+  stage: ScoreComputation["stage"],
+  score: number,
+  factors: Record<string, number>,
+  inputScore?: number,
+): ScoreComputation {
+  return {
+    stage,
+    ...(inputScore === undefined ? {} : { inputScore }),
+    score,
+    factors,
+    observations: {},
+    missingSignals: [],
+  };
 }
 
 function isKgExpansion(edge: SearchEdge): boolean {

--- a/packages/core/src/query/seed-fusion.ts
+++ b/packages/core/src/query/seed-fusion.ts
@@ -1,0 +1,72 @@
+import type { SearchSeed } from "./bidirectional-retriever.js";
+import type { RankedRetrievalObservation } from "./traversal-scoring.js";
+
+/** Merges provider observations without adding incomparable native scores. */
+export function fuseSearchSeeds(seeds: readonly SearchSeed[]): SearchSeed[] {
+  const fused = new Map<string, SearchSeed>();
+  for (const seed of seeds) {
+    const key = `${seed.node.kind}:${seed.node.id}`;
+    const previous = fused.get(key);
+    if (!previous) {
+      fused.set(key, seed);
+      continue;
+    }
+    const previousQuery = previous.observations?.query;
+    const nextQuery = seed.observations?.query;
+    fused.set(key, {
+      node: seed.node,
+      ...maxLegacyScore(previous, seed),
+      observations: {
+        fallback: Boolean(previous.observations?.fallback && seed.observations?.fallback),
+        providers: Array.from(
+          new Set([
+            ...(previous.observations?.providers ?? []),
+            ...(seed.observations?.providers ?? []),
+          ]),
+        ).sort(),
+        query: {
+          exactMatch: Boolean(previousQuery?.exactMatch || nextQuery?.exactMatch),
+          aliasMatch: Boolean(previousQuery?.aliasMatch || nextQuery?.aliasMatch),
+          ...optionalRank("lexical", betterRank(previousQuery?.lexical, nextQuery?.lexical)),
+          ...optionalRank("vector", betterRank(previousQuery?.vector, nextQuery?.vector)),
+          ...maxReranker(previousQuery?.rerankerScore, nextQuery?.rerankerScore),
+        },
+      },
+    });
+  }
+  return Array.from(fused.values());
+}
+
+function betterRank(
+  left: RankedRetrievalObservation | undefined,
+  right: RankedRetrievalObservation | undefined,
+): RankedRetrievalObservation | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  if (left.rank !== right.rank) return left.rank < right.rank ? left : right;
+  const leftScore = left.normalizedScore ?? Number.NEGATIVE_INFINITY;
+  const rightScore = right.normalizedScore ?? Number.NEGATIVE_INFINITY;
+  return leftScore >= rightScore ? left : right;
+}
+
+function optionalRank(
+  key: "lexical" | "vector",
+  value: RankedRetrievalObservation | undefined,
+): Partial<Record<"lexical" | "vector", RankedRetrievalObservation>> {
+  return value === undefined ? {} : { [key]: value };
+}
+
+function maxReranker(
+  left: number | undefined,
+  right: number | undefined,
+): { readonly rerankerScore?: number } {
+  return left === undefined && right === undefined
+    ? {}
+    : { rerankerScore: Math.max(left ?? 0, right ?? 0) };
+}
+
+function maxLegacyScore(left: SearchSeed, right: SearchSeed): { readonly score?: number } {
+  return left.score === undefined && right.score === undefined
+    ? {}
+    : { score: Math.max(left.score ?? 0, right.score ?? 0) };
+}

--- a/packages/core/src/query/traversal-scoring.ts
+++ b/packages/core/src/query/traversal-scoring.ts
@@ -1,0 +1,804 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Raw observations used by traversal scoring. Adapters should report what they
+ * observed here instead of turning observations into opaque, hand-tuned scores.
+ */
+export interface RankedRetrievalObservation {
+  readonly rank: number;
+  readonly candidateCount: number;
+  /** Optional native score, normalized to [0, 1] by the producing adapter. */
+  readonly normalizedScore?: number;
+}
+
+export interface FanoutObservation {
+  /** Number of neighbors returned to the traversal after its bounded cut. */
+  readonly returnedCount: number;
+  /** Total visible neighbors before the bounded cut. */
+  readonly candidateCount: number;
+}
+
+export type SignalApplicability = "applicable" | "not-applicable";
+
+export interface QueryMatchObservation {
+  readonly exactMatch?: boolean;
+  readonly aliasMatch?: boolean;
+  readonly lexical?: RankedRetrievalObservation;
+  readonly vector?: RankedRetrievalObservation;
+  readonly rerankerScore?: number;
+}
+
+export type StructuralObservation =
+  | { readonly kind: "deterministic" }
+  | { readonly kind: "declared"; readonly weight?: number }
+  | {
+      readonly kind: "extracted";
+      readonly confidence?: number;
+      readonly extractorVersion?: string;
+    }
+  | { readonly kind: "inferred"; readonly confidence?: number };
+
+export interface EvidenceSupportObservation {
+  readonly activeEvidenceCount?: number;
+  readonly curatedEvidenceCount?: number;
+  readonly derivedEvidenceCount?: number;
+  readonly distinctResourceCount?: number;
+  readonly conflictCount?: number;
+  readonly staleEvidenceCount?: number;
+}
+
+export interface SearchSeedObservations {
+  readonly query?: QueryMatchObservation;
+  readonly fallback?: boolean;
+  readonly providers?: readonly string[];
+}
+
+export interface SearchEdgeObservations {
+  readonly structural?: StructuralObservation;
+  readonly query?: QueryMatchObservation;
+  readonly support?: EvidenceSupportObservation;
+  readonly fanout?: FanoutObservation;
+  readonly queryApplicability?: SignalApplicability;
+  readonly supportApplicability?: SignalApplicability;
+}
+
+export interface EvidenceHitObservations {
+  readonly support?: EvidenceSupportObservation;
+  readonly origin?: "curated" | "derived";
+  readonly freshnessDays?: number;
+  readonly confidence?: number;
+  readonly supportApplicability?: SignalApplicability;
+  readonly confidenceApplicability?: SignalApplicability;
+  readonly freshnessApplicability?: SignalApplicability;
+}
+
+export type ScoreStage = "seed" | "edge" | "evidence";
+
+export interface ScoreComputation {
+  readonly stage: ScoreStage;
+  readonly inputScore?: number;
+  readonly score: number;
+  readonly factors: Readonly<Record<string, number>>;
+  readonly observations: Readonly<Record<string, number | boolean | string>>;
+  readonly missingSignals: readonly string[];
+}
+
+export interface TraversalScoreBreakdown {
+  readonly profileId: string;
+  readonly profileVersion: number;
+  readonly profileDigest: string;
+  readonly seed: ScoreComputation;
+  readonly edges: readonly ScoreComputation[];
+  readonly evidence: ScoreComputation;
+  readonly finalScore: number;
+}
+
+export interface TraversalScoringProfile {
+  readonly id: string;
+  readonly version: number;
+  readonly featureSchemaVersion: string;
+  readonly description?: string;
+  readonly seed: {
+    readonly exactMatchScore: number;
+    readonly aliasMatchScore: number;
+    readonly fallbackScore: number;
+    readonly missingQueryScore: number;
+    readonly observedQueryFloor: number;
+    readonly lexicalWeight: number;
+    readonly vectorWeight: number;
+    readonly rerankerWeight: number;
+  };
+  readonly edge: {
+    readonly hopFactor: number;
+    readonly kgExpansionFactor: number;
+    readonly queryFloor: number;
+    readonly supportFloor: number;
+    readonly missingQueryFactor: number;
+    readonly missingSupportFactor: number;
+    readonly structuralPriors: {
+      readonly deterministic: number;
+      readonly declared: number;
+      readonly extracted: number;
+      readonly inferred: number;
+      readonly missing: number;
+    };
+  };
+  readonly supportEncoding: {
+    readonly reliabilityWeight: number;
+    readonly diversityWeight: number;
+    readonly volumeWeight: number;
+    readonly derivedEvidenceWeight: number;
+    readonly staleEvidenceWeight: number;
+    readonly diversitySaturation: number;
+    readonly volumeSaturation: number;
+  };
+  readonly evidence: {
+    readonly activeFactFactor: number;
+    readonly conflictFactFactor: number;
+    readonly noFactFactor: number;
+    readonly curatedOriginFactor: number;
+    readonly derivedOriginFactor: number;
+    readonly missingOriginFactor: number;
+    readonly supportFloor: number;
+    readonly missingSupportFactor: number;
+    readonly confidenceFloor: number;
+    readonly missingConfidenceFactor: number;
+    readonly freshnessHalfLifeDays: number;
+    readonly minimumFreshnessFactor: number;
+  };
+}
+
+export interface ScorePolicyDescriptor {
+  readonly profileId: string;
+  readonly profileVersion: number;
+  readonly profileDigest: string;
+  readonly featureSchemaVersion: string;
+}
+
+export const TRAVERSAL_FEATURE_SCHEMA_VERSION = "n-layer-observations-v1" as const;
+
+export interface SeedScoreInput {
+  readonly legacyScore?: number;
+  readonly observations?: SearchSeedObservations;
+  readonly nodeKind?: "ontology" | "resource" | "chunk" | "entity" | "fact";
+}
+
+export interface EdgeScoreInput {
+  readonly operation: "lift" | "expand" | "ground";
+  readonly fromKind: "ontology" | "resource" | "chunk" | "entity" | "fact";
+  readonly toKind: "ontology" | "resource" | "chunk" | "entity" | "fact";
+  readonly legacyConfidence?: number;
+  readonly legacyQueryRelevance?: number;
+  readonly legacyEvidenceSupport?: number;
+  readonly observations?: SearchEdgeObservations;
+}
+
+export interface EvidenceScoreInput {
+  readonly legacyScore?: number;
+  readonly factStatus?: "active" | "conflict";
+  readonly observations?: EvidenceHitObservations;
+}
+
+export interface ExplainableTraversalScorePolicy {
+  readonly explainable: true;
+  readonly descriptor: ScorePolicyDescriptor;
+  seedScore(input: SeedScoreInput): ScoreComputation;
+  edgeScore(parentScore: number, input: EdgeScoreInput, hop: number): ScoreComputation;
+  evidenceScore(pathScore: number, input: EvidenceScoreInput): ScoreComputation;
+}
+
+/**
+ * A reusable policy can bind query-local intent once, keeping query analysis
+ * inside the scoring module instead of duplicating it across graph adapters.
+ */
+export interface QueryAdaptiveTraversalScorePolicy {
+  readonly queryAdaptive: true;
+  readonly descriptor: ScorePolicyDescriptor;
+  bind(question: string): ExplainableTraversalScorePolicy;
+}
+
+export const DEFAULT_CALIBRATED_SCORING_PROFILE: TraversalScoringProfile = {
+  id: "calibrated-v2",
+  version: 1,
+  featureSchemaVersion: TRAVERSAL_FEATURE_SCHEMA_VERSION,
+  description: "Observation-based monotonic traversal scoring with explicit missing signals",
+  seed: {
+    exactMatchScore: 1,
+    aliasMatchScore: 0.94,
+    fallbackScore: 0.08,
+    missingQueryScore: 0,
+    observedQueryFloor: 0.05,
+    lexicalWeight: 1,
+    vectorWeight: 1,
+    rerankerWeight: 1.25,
+  },
+  edge: {
+    hopFactor: 0.92,
+    kgExpansionFactor: 0.96,
+    queryFloor: 0.55,
+    supportFloor: 0.65,
+    missingQueryFactor: 1,
+    missingSupportFactor: 1,
+    structuralPriors: {
+      deterministic: 1,
+      declared: 0.95,
+      extracted: 0.9,
+      inferred: 0.78,
+      missing: 0.72,
+    },
+  },
+  supportEncoding: {
+    reliabilityWeight: 0.55,
+    diversityWeight: 0.25,
+    volumeWeight: 0.2,
+    derivedEvidenceWeight: 0.75,
+    staleEvidenceWeight: 0.5,
+    diversitySaturation: 2,
+    volumeSaturation: 3,
+  },
+  evidence: {
+    activeFactFactor: 1,
+    conflictFactFactor: 0.55,
+    noFactFactor: 0.82,
+    curatedOriginFactor: 1,
+    derivedOriginFactor: 0.92,
+    missingOriginFactor: 1,
+    supportFloor: 0.7,
+    missingSupportFactor: 1,
+    confidenceFloor: 0.75,
+    missingConfidenceFactor: 1,
+    freshnessHalfLifeDays: 180,
+    minimumFreshnessFactor: 0.75,
+  },
+};
+
+export class CalibratedTraversalScorePolicy implements ExplainableTraversalScorePolicy {
+  readonly explainable = true as const;
+  readonly descriptor: ScorePolicyDescriptor;
+
+  constructor(readonly profile: TraversalScoringProfile = DEFAULT_CALIBRATED_SCORING_PROFILE) {
+    validateTraversalScoringProfile(profile);
+    this.descriptor = {
+      profileId: profile.id,
+      profileVersion: profile.version,
+      profileDigest: scoringProfileDigest(profile),
+      featureSchemaVersion: profile.featureSchemaVersion,
+    };
+  }
+
+  seedScore(input: SeedScoreInput): ScoreComputation {
+    const missingSignals: string[] = [];
+    const observations: Record<string, number | boolean | string> = {};
+    const query = input.observations?.query;
+    let score: number;
+
+    if (query?.exactMatch) {
+      observations.exactMatch = true;
+      score = this.profile.seed.exactMatchScore;
+    } else if (query?.aliasMatch) {
+      observations.aliasMatch = true;
+      score = this.profile.seed.aliasMatchScore;
+    } else {
+      const combined = combineQueryObservations(query, this.profile.seed, observations);
+      if (combined === undefined) {
+        missingSignals.push("seed.query");
+        score = input.observations?.fallback
+          ? this.profile.seed.fallbackScore
+          : this.profile.seed.missingQueryScore;
+      } else {
+        score = interpolate(this.profile.seed.observedQueryFloor, combined);
+      }
+    }
+
+    if (input.observations?.fallback) observations.fallback = true;
+    return computation("seed", undefined, score, { query: score }, observations, missingSignals);
+  }
+
+  edgeScore(parentScore: number, input: EdgeScoreInput, _hop: number): ScoreComputation {
+    const missingSignals: string[] = [];
+    const observations: Record<string, number | boolean | string> = {};
+    const structural = structuralFactor(
+      input.observations?.structural,
+      this.profile.edge.structuralPriors,
+      observations,
+      missingSignals,
+    );
+    const queryMatch = combineQueryObservations(
+      input.observations?.query,
+      this.profile.seed,
+      observations,
+    );
+    const queryNotApplicable = input.observations?.queryApplicability === "not-applicable";
+    const query =
+      queryMatch === undefined
+        ? queryNotApplicable
+          ? 1
+          : this.profile.edge.missingQueryFactor
+        : interpolate(this.profile.edge.queryFloor, queryMatch);
+    if (queryMatch === undefined && !queryNotApplicable) missingSignals.push("edge.query");
+    if (queryNotApplicable) observations.queryApplicability = "not-applicable";
+
+    const observedSupport = supportStrength(
+      input.observations?.support,
+      observations,
+      this.profile.supportEncoding,
+    );
+    const supportNotApplicable = input.observations?.supportApplicability === "not-applicable";
+    const support =
+      observedSupport === undefined
+        ? supportNotApplicable
+          ? 1
+          : this.profile.edge.missingSupportFactor
+        : interpolate(this.profile.edge.supportFloor, observedSupport);
+    if (observedSupport === undefined && !supportNotApplicable) missingSignals.push("edge.support");
+    if (supportNotApplicable) observations.supportApplicability = "not-applicable";
+
+    const kgExpansion = isKgExpansion(input) ? this.profile.edge.kgExpansionFactor : 1;
+    const factors = {
+      structural,
+      query,
+      support,
+      hop: this.profile.edge.hopFactor,
+      kgExpansion,
+    };
+    const score = multiplyInLogSpace(parentScore, Object.values(factors));
+    return computation("edge", parentScore, score, factors, observations, missingSignals);
+  }
+
+  evidenceScore(pathScore: number, input: EvidenceScoreInput): ScoreComputation {
+    const missingSignals: string[] = [];
+    const observations: Record<string, number | boolean | string> = {};
+    const fact =
+      input.factStatus === "active"
+        ? this.profile.evidence.activeFactFactor
+        : input.factStatus === "conflict"
+          ? this.profile.evidence.conflictFactFactor
+          : this.profile.evidence.noFactFactor;
+    observations.factStatus = input.factStatus ?? "none";
+
+    const origin = input.observations?.origin;
+    const originFactor =
+      origin === "curated"
+        ? this.profile.evidence.curatedOriginFactor
+        : origin === "derived"
+          ? this.profile.evidence.derivedOriginFactor
+          : this.profile.evidence.missingOriginFactor;
+    if (origin === undefined) missingSignals.push("evidence.origin");
+    else observations.origin = origin;
+
+    const observedSupport = supportStrength(
+      input.observations?.support,
+      observations,
+      this.profile.supportEncoding,
+    );
+    const supportNotApplicable = input.observations?.supportApplicability === "not-applicable";
+    const support =
+      observedSupport === undefined
+        ? supportNotApplicable
+          ? 1
+          : this.profile.evidence.missingSupportFactor
+        : interpolate(this.profile.evidence.supportFloor, observedSupport);
+    if (observedSupport === undefined && !supportNotApplicable) {
+      missingSignals.push("evidence.support");
+    }
+    if (supportNotApplicable) observations.supportApplicability = "not-applicable";
+
+    const observedConfidence = input.observations?.confidence;
+    const confidenceNotApplicable =
+      input.observations?.confidenceApplicability === "not-applicable";
+    const confidence =
+      observedConfidence === undefined || !Number.isFinite(observedConfidence)
+        ? confidenceNotApplicable
+          ? 1
+          : this.profile.evidence.missingConfidenceFactor
+        : interpolate(this.profile.evidence.confidenceFloor, observedConfidence);
+    if (
+      (observedConfidence === undefined || !Number.isFinite(observedConfidence)) &&
+      !confidenceNotApplicable
+    ) {
+      missingSignals.push("evidence.confidence");
+    } else {
+      if (confidenceNotApplicable) observations.confidenceApplicability = "not-applicable";
+      else observations.confidence = clampScore(observedConfidence ?? 0);
+    }
+
+    const freshnessDays = input.observations?.freshnessDays;
+    let freshness = 1;
+    const freshnessNotApplicable = input.observations?.freshnessApplicability === "not-applicable";
+    if (
+      (freshnessDays === undefined || !Number.isFinite(freshnessDays)) &&
+      !freshnessNotApplicable
+    ) {
+      missingSignals.push("evidence.freshnessDays");
+    } else if (freshnessNotApplicable) {
+      observations.freshnessApplicability = "not-applicable";
+    } else {
+      observations.freshnessDays = Math.max(0, freshnessDays ?? 0);
+      freshness = Math.max(
+        this.profile.evidence.minimumFreshnessFactor,
+        2 ** (-Math.max(0, freshnessDays ?? 0) / this.profile.evidence.freshnessHalfLifeDays),
+      );
+    }
+
+    const factors = { fact, origin: originFactor, support, confidence, freshness };
+    const score = multiplyInLogSpace(pathScore, Object.values(factors));
+    return computation("evidence", pathScore, score, factors, observations, missingSignals);
+  }
+}
+
+export function validateTraversalScoringProfile(profile: TraversalScoringProfile): void {
+  if (typeof profile?.id !== "string" || profile.id.trim().length === 0) {
+    throw new Error("Scoring profile id must not be empty");
+  }
+  if (!Number.isInteger(profile.version) || profile.version < 1) {
+    throw new Error("Scoring profile version must be a positive integer");
+  }
+  if (
+    typeof profile.featureSchemaVersion !== "string" ||
+    profile.featureSchemaVersion.trim().length === 0
+  ) {
+    throw new Error("Scoring profile featureSchemaVersion must not be empty");
+  }
+  assertExactKeys(profile, "profile", [
+    "id",
+    "version",
+    "featureSchemaVersion",
+    "description",
+    "seed",
+    "edge",
+    "supportEncoding",
+    "evidence",
+  ]);
+  assertExactKeys(profile.seed, "profile.seed", [
+    "exactMatchScore",
+    "aliasMatchScore",
+    "fallbackScore",
+    "missingQueryScore",
+    "observedQueryFloor",
+    "lexicalWeight",
+    "vectorWeight",
+    "rerankerWeight",
+  ]);
+  assertExactKeys(profile.edge, "profile.edge", [
+    "hopFactor",
+    "kgExpansionFactor",
+    "queryFloor",
+    "supportFloor",
+    "missingQueryFactor",
+    "missingSupportFactor",
+    "structuralPriors",
+  ]);
+  assertExactKeys(profile.edge?.structuralPriors, "profile.edge.structuralPriors", [
+    "deterministic",
+    "declared",
+    "extracted",
+    "inferred",
+    "missing",
+  ]);
+  assertExactKeys(profile.supportEncoding, "profile.supportEncoding", [
+    "reliabilityWeight",
+    "diversityWeight",
+    "volumeWeight",
+    "derivedEvidenceWeight",
+    "staleEvidenceWeight",
+    "diversitySaturation",
+    "volumeSaturation",
+  ]);
+  assertExactKeys(profile.evidence, "profile.evidence", [
+    "activeFactFactor",
+    "conflictFactFactor",
+    "noFactFactor",
+    "curatedOriginFactor",
+    "derivedOriginFactor",
+    "missingOriginFactor",
+    "supportFloor",
+    "missingSupportFactor",
+    "confidenceFloor",
+    "missingConfidenceFactor",
+    "freshnessHalfLifeDays",
+    "minimumFreshnessFactor",
+  ]);
+  const requiredNumbers: ReadonlyArray<readonly [string, unknown]> = [
+    ["profile.seed.exactMatchScore", profile.seed?.exactMatchScore],
+    ["profile.seed.aliasMatchScore", profile.seed?.aliasMatchScore],
+    ["profile.seed.fallbackScore", profile.seed?.fallbackScore],
+    ["profile.seed.missingQueryScore", profile.seed?.missingQueryScore],
+    ["profile.seed.observedQueryFloor", profile.seed?.observedQueryFloor],
+    ["profile.seed.lexicalWeight", profile.seed?.lexicalWeight],
+    ["profile.seed.vectorWeight", profile.seed?.vectorWeight],
+    ["profile.seed.rerankerWeight", profile.seed?.rerankerWeight],
+    ["profile.edge.hopFactor", profile.edge?.hopFactor],
+    ["profile.edge.kgExpansionFactor", profile.edge?.kgExpansionFactor],
+    ["profile.edge.queryFloor", profile.edge?.queryFloor],
+    ["profile.edge.supportFloor", profile.edge?.supportFloor],
+    ["profile.edge.missingQueryFactor", profile.edge?.missingQueryFactor],
+    ["profile.edge.missingSupportFactor", profile.edge?.missingSupportFactor],
+    ["profile.edge.structuralPriors.deterministic", profile.edge?.structuralPriors?.deterministic],
+    ["profile.edge.structuralPriors.declared", profile.edge?.structuralPriors?.declared],
+    ["profile.edge.structuralPriors.extracted", profile.edge?.structuralPriors?.extracted],
+    ["profile.edge.structuralPriors.inferred", profile.edge?.structuralPriors?.inferred],
+    ["profile.edge.structuralPriors.missing", profile.edge?.structuralPriors?.missing],
+    ["profile.supportEncoding.reliabilityWeight", profile.supportEncoding?.reliabilityWeight],
+    ["profile.supportEncoding.diversityWeight", profile.supportEncoding?.diversityWeight],
+    ["profile.supportEncoding.volumeWeight", profile.supportEncoding?.volumeWeight],
+    [
+      "profile.supportEncoding.derivedEvidenceWeight",
+      profile.supportEncoding?.derivedEvidenceWeight,
+    ],
+    ["profile.supportEncoding.staleEvidenceWeight", profile.supportEncoding?.staleEvidenceWeight],
+    ["profile.supportEncoding.diversitySaturation", profile.supportEncoding?.diversitySaturation],
+    ["profile.supportEncoding.volumeSaturation", profile.supportEncoding?.volumeSaturation],
+    ["profile.evidence.activeFactFactor", profile.evidence?.activeFactFactor],
+    ["profile.evidence.conflictFactFactor", profile.evidence?.conflictFactFactor],
+    ["profile.evidence.noFactFactor", profile.evidence?.noFactFactor],
+    ["profile.evidence.curatedOriginFactor", profile.evidence?.curatedOriginFactor],
+    ["profile.evidence.derivedOriginFactor", profile.evidence?.derivedOriginFactor],
+    ["profile.evidence.missingOriginFactor", profile.evidence?.missingOriginFactor],
+    ["profile.evidence.supportFloor", profile.evidence?.supportFloor],
+    ["profile.evidence.missingSupportFactor", profile.evidence?.missingSupportFactor],
+    ["profile.evidence.confidenceFloor", profile.evidence?.confidenceFloor],
+    ["profile.evidence.missingConfidenceFactor", profile.evidence?.missingConfidenceFactor],
+    ["profile.evidence.freshnessHalfLifeDays", profile.evidence?.freshnessHalfLifeDays],
+    ["profile.evidence.minimumFreshnessFactor", profile.evidence?.minimumFreshnessFactor],
+  ];
+  for (const [path, value] of requiredNumbers) {
+    if (typeof value !== "number") throw new Error(`${path} is required and must be a number`);
+  }
+  const supportWeightSum =
+    profile.supportEncoding.reliabilityWeight +
+    profile.supportEncoding.diversityWeight +
+    profile.supportEncoding.volumeWeight;
+  if (Math.abs(supportWeightSum - 1) > 1e-9) {
+    throw new Error("Support encoding reliability, diversity, and volume weights must sum to one");
+  }
+  for (const [path, value] of [
+    [
+      "profile.supportEncoding.derivedEvidenceWeight",
+      profile.supportEncoding.derivedEvidenceWeight,
+    ],
+    ["profile.supportEncoding.staleEvidenceWeight", profile.supportEncoding.staleEvidenceWeight],
+  ] as const) {
+    if (value < 0 || value > 1) throw new Error(`${path} must be between zero and one`);
+  }
+  visitNumbers(profile, "profile", (path, value) => {
+    if (!Number.isFinite(value)) throw new Error(`${path} must be finite`);
+    if (path === "profile.version") return;
+    if (path.endsWith("Weight")) {
+      if (value <= 0) throw new Error(`${path} must be greater than zero`);
+      return;
+    }
+    if (path.endsWith("freshnessHalfLifeDays")) {
+      if (value <= 0) throw new Error(`${path} must be greater than zero`);
+      return;
+    }
+    if (path.endsWith("Saturation")) {
+      if (value <= 0) throw new Error(`${path} must be greater than zero`);
+      return;
+    }
+    if (value < 0 || value > 1) throw new Error(`${path} must be between zero and one`);
+  });
+}
+
+export function scoringProfileDigest(profile: TraversalScoringProfile): string {
+  return `sha256:${createHash("sha256").update(canonicalJson(profile)).digest("hex")}`;
+}
+
+function combineQueryObservations(
+  query: QueryMatchObservation | undefined,
+  weights: TraversalScoringProfile["seed"],
+  output: Record<string, number | boolean | string>,
+): number | undefined {
+  if (!query) return undefined;
+  if (query.exactMatch) {
+    output.exactMatch = true;
+    return weights.exactMatchScore;
+  }
+  if (query.aliasMatch) {
+    output.aliasMatch = true;
+    return weights.aliasMatchScore;
+  }
+  const values: Array<{ value: number; weight: number }> = [];
+  const lexical = rankedObservationScore(query.lexical);
+  if (lexical !== undefined) {
+    output.lexical = lexical;
+    recordRankedObservation("lexical", query.lexical, output);
+    values.push({ value: lexical, weight: weights.lexicalWeight });
+  }
+  const vector = rankedObservationScore(query.vector);
+  if (vector !== undefined) {
+    output.vector = vector;
+    recordRankedObservation("vector", query.vector, output);
+    values.push({ value: vector, weight: weights.vectorWeight });
+  }
+  if (query.rerankerScore !== undefined) {
+    const reranker = clampScore(query.rerankerScore);
+    output.reranker = reranker;
+    values.push({ value: reranker, weight: weights.rerankerWeight });
+  }
+  if (values.length === 0) return undefined;
+  const totalWeight = values.reduce((sum, item) => sum + item.weight, 0);
+  return values.reduce((sum, item) => sum + item.value * item.weight, 0) / totalWeight;
+}
+
+function recordRankedObservation(
+  prefix: "lexical" | "vector",
+  observation: RankedRetrievalObservation | undefined,
+  output: Record<string, number | boolean | string>,
+): void {
+  if (!observation) return;
+  output[`${prefix}Rank`] = finitePositiveInteger(observation.rank);
+  output[`${prefix}CandidateCount`] = finitePositiveInteger(observation.candidateCount);
+  if (observation.normalizedScore !== undefined) {
+    output[`${prefix}NormalizedScore`] = clampScore(observation.normalizedScore);
+  }
+}
+
+function rankedObservationScore(
+  observation: RankedRetrievalObservation | undefined,
+): number | undefined {
+  if (!observation) return undefined;
+  const candidateCount = finitePositiveInteger(observation.candidateCount);
+  const rank = Math.min(candidateCount, finitePositiveInteger(observation.rank));
+  // Multi-provider fusion uses ordinal position, not incomparable provider
+  // score scales. A normalized score is only used when there is no ranking
+  // distribution (for example, token overlap on a single graph edge).
+  if (candidateCount === 1 && observation.normalizedScore !== undefined) {
+    return clampScore(observation.normalizedScore);
+  }
+  return candidateCount === 1 ? 1 : (candidateCount - rank) / (candidateCount - 1);
+}
+
+function finitePositiveInteger(value: number): number {
+  return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 1;
+}
+
+function structuralFactor(
+  structural: StructuralObservation | undefined,
+  priors: TraversalScoringProfile["edge"]["structuralPriors"],
+  output: Record<string, number | boolean | string>,
+  missingSignals: string[],
+): number {
+  if (!structural) {
+    missingSignals.push("edge.structural");
+    return priors.missing;
+  }
+  output.structuralKind = structural.kind;
+  if (structural.kind === "deterministic") return priors.deterministic;
+  if (structural.kind === "declared") {
+    if (structural.weight === undefined) {
+      missingSignals.push("edge.structural.weight");
+      return priors.declared;
+    }
+    output.structuralWeight = clampScore(structural.weight);
+    return priors.declared * clampScore(structural.weight);
+  }
+  const confidence = structural.confidence;
+  if (confidence === undefined) {
+    missingSignals.push("edge.structural.confidence");
+    return priors[structural.kind];
+  }
+  output.structuralConfidence = clampScore(confidence);
+  if (structural.kind === "extracted" && structural.extractorVersion) {
+    output.extractorVersion = structural.extractorVersion;
+  }
+  return priors[structural.kind] * clampScore(confidence);
+}
+
+function supportStrength(
+  support: EvidenceSupportObservation | undefined,
+  output: Record<string, number | boolean | string>,
+  encoding: TraversalScoringProfile["supportEncoding"],
+): number | undefined {
+  if (!support) return undefined;
+  const active = nonNegative(support.activeEvidenceCount);
+  const curated = nonNegative(support.curatedEvidenceCount);
+  const derived = nonNegative(support.derivedEvidenceCount);
+  const resources = nonNegative(support.distinctResourceCount);
+  const conflicts = nonNegative(support.conflictCount);
+  const stale = nonNegative(support.staleEvidenceCount);
+  const present = [active, curated, derived, resources, conflicts, stale].some(
+    (value) => value !== undefined,
+  );
+  if (!present) return undefined;
+
+  const hasOriginCounts = curated !== undefined || derived !== undefined;
+  const positiveCount = hasOriginCounts
+    ? (curated ?? 0) + encoding.derivedEvidenceWeight * (derived ?? 0)
+    : (active ?? 0);
+  const negativeCount = (conflicts ?? 0) + encoding.staleEvidenceWeight * (stale ?? 0);
+  const reliability =
+    positiveCount + negativeCount === 0 ? 0 : positiveCount / (positiveCount + negativeCount);
+  const diversity = 1 - Math.exp(-(resources ?? 0) / encoding.diversitySaturation);
+  const volume = 1 - Math.exp(-positiveCount / encoding.volumeSaturation);
+  const score =
+    encoding.reliabilityWeight * reliability +
+    encoding.diversityWeight * diversity +
+    encoding.volumeWeight * volume;
+
+  if (active !== undefined) output.activeEvidenceCount = active;
+  if (curated !== undefined) output.curatedEvidenceCount = curated;
+  if (derived !== undefined) output.derivedEvidenceCount = derived;
+  if (resources !== undefined) output.distinctResourceCount = resources;
+  if (conflicts !== undefined) output.conflictCount = conflicts;
+  if (stale !== undefined) output.staleEvidenceCount = stale;
+  return clampScore(score);
+}
+
+function computation(
+  stage: ScoreStage,
+  inputScore: number | undefined,
+  score: number,
+  factors: Record<string, number>,
+  observations: Record<string, number | boolean | string>,
+  missingSignals: readonly string[],
+): ScoreComputation {
+  return {
+    stage,
+    ...(inputScore === undefined ? {} : { inputScore: clampScore(inputScore) }),
+    score: clampScore(score),
+    factors,
+    observations,
+    missingSignals,
+  };
+}
+
+function isKgExpansion(input: EdgeScoreInput): boolean {
+  return (
+    input.operation === "expand" &&
+    ([input.fromKind, input.toKind].includes("entity") ||
+      [input.fromKind, input.toKind].includes("fact"))
+  );
+}
+
+function interpolate(floor: number, value: number): number {
+  return floor + (1 - floor) * clampScore(value);
+}
+
+function nonNegative(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  return Math.max(0, value);
+}
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function multiplyInLogSpace(inputScore: number, factors: readonly number[]): number {
+  const values = [clampScore(inputScore), ...factors.map(clampScore)];
+  if (values.some((value) => value === 0)) return 0;
+  return clampScore(Math.exp(values.reduce((sum, value) => sum + Math.log(value), 0)));
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function visitNumbers(
+  value: unknown,
+  path: string,
+  visitor: (path: string, value: number) => void,
+): void {
+  if (typeof value === "number") {
+    visitor(path, value);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value)) visitNumbers(child, `${path}.${key}`, visitor);
+}
+
+function assertExactKeys(value: unknown, path: string, allowed: readonly string[]): void {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return;
+  const allowedKeys = new Set(allowed);
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) throw new Error(`${path}.${key} is not a recognized profile field`);
+  }
+}

--- a/packages/core/tests/adaptive-traversal-scoring.test.ts
+++ b/packages/core/tests/adaptive-traversal-scoring.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  AdaptiveRouteTraversalScorePolicy,
+  BidirectionalNLayerRetriever,
+  type EdgeScoreInput,
+  type Principal,
+  type SearchGraphPort,
+} from "../src/index.js";
+
+const principal: Principal = {
+  organizationId: "adaptive-test",
+  subjectId: "user:1",
+  groupIds: [],
+};
+
+function resourceGrounding(
+  candidateCount: number,
+  returnedCount: number,
+  rank = 1,
+): EdgeScoreInput {
+  return {
+    operation: "ground",
+    fromKind: "resource",
+    toKind: "chunk",
+    observations: {
+      structural: { kind: "deterministic" },
+      query: { lexical: { rank, candidateCount, normalizedScore: 0.8 } },
+      fanout: { returnedCount, candidateCount },
+      supportApplicability: "not-applicable",
+    },
+  };
+}
+
+describe("AdaptiveRouteTraversalScorePolicy", () => {
+  it("downweights a broad resource route from observed fanout rather than a dataset name", () => {
+    const policy = new AdaptiveRouteTraversalScorePolicy().bind("What treatment is recommended?");
+    const narrow = policy.edgeScore(1, resourceGrounding(4, 4), 1);
+    const broad = policy.edgeScore(1, resourceGrounding(1_385, 10), 1);
+
+    expect(narrow.factors.adaptiveRouteGate).toBe(0.8);
+    expect(broad.factors.adaptiveRouteGate).toBeLessThan(0.4);
+    expect(narrow.score).toBeGreaterThan(broad.score);
+    expect(broad.observations).toMatchObject({
+      route: "resource:ground:chunk",
+      fanoutCandidateCount: 1385,
+      queryIntent: "lookup",
+    });
+  });
+
+  it("uses query-local intent to permit broad resource coverage for a summary", () => {
+    const lookup = new AdaptiveRouteTraversalScorePolicy().bind("What treatment is recommended?");
+    const summary = new AdaptiveRouteTraversalScorePolicy().bind("Summarize the main themes");
+    const edge = resourceGrounding(1_385, 10, 1);
+
+    expect(summary.edgeScore(1, edge, 1).score).toBeGreaterThan(lookup.edgeScore(1, edge, 1).score);
+    expect(summary.edgeScore(1, edge, 1).observations.queryIntent).toBe("summary");
+  });
+
+  it.each([
+    ["Compare checkout and payment", "comparison"],
+    ["결제와 환불의 차이를 비교해 줘", "comparison"],
+    ["전체 내용을 요약해 줘", "summary"],
+  ] as const)("classifies %s as %s without corpus metadata", (question, expectedIntent) => {
+    const scored = new AdaptiveRouteTraversalScorePolicy()
+      .bind(question)
+      .edgeScore(1, resourceGrounding(10, 5), 1);
+
+    expect(scored.observations.queryIntent).toBe(expectedIntent);
+  });
+
+  it("decays lower neighbor ranks within the same dynamic route", () => {
+    const policy = new AdaptiveRouteTraversalScorePolicy().bind("specific fact");
+
+    expect(policy.edgeScore(1, resourceGrounding(100, 10, 1), 1).score).toBeGreaterThan(
+      policy.edgeScore(1, resourceGrounding(100, 10, 10), 1).score,
+    );
+  });
+
+  it("does not mistake the best item in a weak route for strong query evidence", () => {
+    const policy = new AdaptiveRouteTraversalScorePolicy().bind("specific fact");
+    const strong = resourceGrounding(1, 1, 1);
+    const weak: EdgeScoreInput = {
+      ...strong,
+      observations: {
+        ...strong.observations,
+        query: { lexical: { rank: 1, candidateCount: 1, normalizedScore: 0.1 } },
+      },
+    };
+
+    expect(policy.edgeScore(1, strong, 1).score).toBeGreaterThan(
+      policy.edgeScore(1, weak, 1).score,
+    );
+    expect(policy.edgeScore(1, weak, 1).factors.routeQueryEvidence).toBe(0.1);
+  });
+
+  it("keeps every public score within the query-local zero-to-one range", () => {
+    const policy = new AdaptiveRouteTraversalScorePolicy().bind("specific fact");
+    const seed = policy.seedScore({
+      nodeKind: "resource",
+      observations: { query: { rerankerScore: 5 } },
+    });
+    const edge = policy.edgeScore(
+      5,
+      {
+        ...resourceGrounding(Number.NaN, -10, Number.POSITIVE_INFINITY),
+        observations: {
+          ...resourceGrounding(1, 1).observations,
+          query: {
+            lexical: {
+              rank: Number.POSITIVE_INFINITY,
+              candidateCount: Number.NaN,
+              normalizedScore: 5,
+            },
+          },
+          fanout: { returnedCount: -10, candidateCount: Number.NaN },
+        },
+      },
+      1,
+    );
+    const evidence = policy.evidenceScore(5, {
+      factStatus: "active",
+      observations: {
+        origin: "curated",
+        confidence: 5,
+        freshnessDays: -100,
+        supportApplicability: "not-applicable",
+      },
+    });
+
+    for (const computation of [seed, edge, evidence]) {
+      expect(computation.score).toBeGreaterThanOrEqual(0);
+      expect(computation.score).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("binds once per retrieval and exposes the selected adaptive route decision", async () => {
+    const graph: SearchGraphPort = {
+      async seed() {
+        return [
+          {
+            node: { kind: "resource", id: "guide" },
+            observations: {
+              providers: ["test-lexical"],
+              query: { lexical: { rank: 1, candidateCount: 1 } },
+            },
+          },
+        ];
+      },
+      async neighbors(node) {
+        return node.kind === "resource"
+          ? [
+              {
+                from: node,
+                to: { kind: "chunk", id: "answer" },
+                operation: "ground",
+                observations: {
+                  structural: { kind: "deterministic" },
+                  query: { lexical: { rank: 1, candidateCount: 50 } },
+                  fanout: { returnedCount: 10, candidateCount: 50 },
+                  supportApplicability: "not-applicable",
+                },
+              },
+            ]
+          : [];
+      },
+      async evidence(node) {
+        return node.kind === "chunk"
+          ? [
+              {
+                evidenceId: "e1",
+                chunkId: node.id,
+                resourceId: "guide",
+                text: "supported answer",
+                observations: {
+                  origin: "derived",
+                  supportApplicability: "not-applicable",
+                  confidenceApplicability: "not-applicable",
+                  freshnessApplicability: "not-applicable",
+                },
+              },
+            ]
+          : [];
+      },
+    };
+
+    const result = await new BidirectionalNLayerRetriever(
+      graph,
+      new AdaptiveRouteTraversalScorePolicy(),
+    ).retrieve({ question: "What is the supported answer?", principal });
+
+    expect(result.evidence[0]?.evidenceId).toBe("e1");
+    expect(result.trace.scoring).toMatchObject({
+      profileId: "adaptive-route-v3",
+      featureSchemaVersion: "n-layer-adaptive-routing-v1",
+      routing: {
+        selectedRouteCounts: { resource: 1 },
+        queryIntent: "lookup",
+      },
+    });
+  });
+});

--- a/packages/core/tests/bidirectional-retriever.test.ts
+++ b/packages/core/tests/bidirectional-retriever.test.ts
@@ -91,6 +91,42 @@ describe("BidirectionalNLayerRetriever", () => {
     expect(result.trace.stoppedBy).toBe("frontier_exhausted");
   });
 
+  it("supports a zero-hop direct-only ablation without consulting graph neighbors", async () => {
+    const graph = new FakeSearchGraph();
+    const direct: SearchNode = { kind: "chunk", id: "direct" };
+    const graphOnly: SearchNode = { kind: "chunk", id: "graph-only" };
+    graph.seeds.push({ node: direct, score: 1 });
+    graph.edges.set(key(direct), [edge(direct, graphOnly, "expand")]);
+    graph.hits.set(key(direct), [
+      {
+        evidenceId: "evidence:direct",
+        chunkId: direct.id,
+        resourceId: "resource:direct",
+        text: "Direct evidence",
+        score: 1,
+      },
+    ]);
+    graph.hits.set(key(graphOnly), [
+      {
+        evidenceId: "evidence:graph-only",
+        chunkId: graphOnly.id,
+        resourceId: "resource:graph",
+        text: "Graph-only evidence",
+        score: 1,
+      },
+    ]);
+
+    const result = await new BidirectionalNLayerRetriever(graph).retrieve({
+      question: "direct",
+      principal,
+      budget: { maxHops: 0 },
+    });
+
+    expect(result.evidence.map((item) => item.evidenceId)).toEqual(["evidence:direct"]);
+    expect(result.evidence[0]?.path).toEqual([]);
+    expect(graph.expanded).toEqual([]);
+  });
+
   it("revisits a node only when a better-scoring path reaches it", async () => {
     const graph = new FakeSearchGraph();
     const start: SearchNode = { kind: "entity", id: "start" };
@@ -257,6 +293,17 @@ describe("BidirectionalNLayerRetriever", () => {
       candidates: 0,
       elapsedMs: 10,
       stoppedBy: "time_budget",
+      averageSelectedPathLength: 0,
+      maxSelectedPathLength: 0,
+      seedProviderCounts: {},
+      scoring: {
+        profileId: "legacy-v1",
+        profileVersion: 1,
+        profileDigest: "builtin:legacy-v1",
+        featureSchemaVersion: "legacy-score-fields-v1",
+        missingSignals: [],
+        missingSignalCounts: {},
+      },
     });
   });
 

--- a/packages/core/tests/knowledge-graph-sync.test.ts
+++ b/packages/core/tests/knowledge-graph-sync.test.ts
@@ -77,12 +77,30 @@ describe("SyncResourceUseCase", () => {
     const repository = new InMemoryKnowledgeGraphRepository();
     const sync = new SyncResourceUseCase(repository, new InMemoryResourceContentStore());
 
-    const result = await sync.execute(orderSnapshot("v1", "paid"));
+    const base = orderSnapshot("v1", "paid");
+    const result = await sync.execute({
+      ...base,
+      ontologyLinks: [
+        { ontologyNodeId: "order", origin: "manual", confidence: 1 },
+        { ontologyNodeId: "payment", origin: "automatic", confidence: 0.7 },
+      ],
+      chunks: base.chunks.map((chunk) => ({
+        ...chunk,
+        ontologyLinks: [{ ontologyNodeId: "order", origin: "deterministic", confidence: 1 }],
+      })),
+    });
     const resource = await repository.getResource(organizationId, result.resourceId);
     const chunks = await repository.listChunks(organizationId, result.resourceId);
 
     expect(resource?.ontologyNodeIds).toEqual(["order", "payment"]);
     expect(chunks[0]?.ontologyNodeIds).toEqual(["order", "payment"]);
+    expect(resource?.ontologyLinks).toMatchObject([
+      { ontologyNodeId: "order", origin: "manual", confidence: 1 },
+      { ontologyNodeId: "payment", origin: "automatic", confidence: 0.7 },
+    ]);
+    expect(chunks[0]?.ontologyLinks).toMatchObject([
+      { ontologyNodeId: "order", origin: "deterministic", confidence: 1 },
+    ]);
   });
 
   it("marks competing active values as conflicts instead of choosing one", async () => {

--- a/packages/core/tests/seed-fusion.test.ts
+++ b/packages/core/tests/seed-fusion.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { type SearchSeed, fuseSearchSeeds } from "../src/index.js";
+
+describe("fuseSearchSeeds", () => {
+  it("keeps lexical and vector ranks as separate observations", () => {
+    const seeds: SearchSeed[] = [
+      {
+        node: { kind: "chunk", id: "c1" },
+        observations: {
+          providers: ["lexical"],
+          query: { lexical: { rank: 2, candidateCount: 10 } },
+        },
+      },
+      {
+        node: { kind: "chunk", id: "c1" },
+        observations: {
+          providers: ["vector"],
+          query: { vector: { rank: 1, candidateCount: 20 } },
+        },
+      },
+    ];
+
+    expect(fuseSearchSeeds(seeds)).toEqual([
+      {
+        node: { kind: "chunk", id: "c1" },
+        observations: {
+          fallback: false,
+          providers: ["lexical", "vector"],
+          query: {
+            exactMatch: false,
+            aliasMatch: false,
+            lexical: { rank: 2, candidateCount: 10 },
+            vector: { rank: 1, candidateCount: 20 },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("keeps the best rank per provider and uses normalized score only to break rank ties", () => {
+    const node = { kind: "chunk" as const, id: "c1" };
+    const seeds: SearchSeed[] = [
+      {
+        node,
+        observations: {
+          providers: ["lexical"],
+          query: { lexical: { rank: 3, candidateCount: 20, normalizedScore: 0.95 } },
+        },
+      },
+      {
+        node,
+        observations: {
+          providers: ["lexical"],
+          query: { lexical: { rank: 2, candidateCount: 20, normalizedScore: 0.4 } },
+        },
+      },
+      {
+        node,
+        observations: {
+          providers: ["lexical"],
+          query: { lexical: { rank: 2, candidateCount: 20, normalizedScore: 0.8 } },
+        },
+      },
+    ];
+
+    expect(fuseSearchSeeds(seeds)[0]?.observations?.query?.lexical).toEqual({
+      rank: 2,
+      candidateCount: 20,
+      normalizedScore: 0.8,
+    });
+  });
+
+  it("combines match signals while keeping fallback exclusive to fallback-only seeds", () => {
+    const node = { kind: "resource" as const, id: "orders" };
+    const fused = fuseSearchSeeds([
+      {
+        node,
+        score: 0.3,
+        observations: {
+          fallback: true,
+          providers: ["fallback", "lexical"],
+          query: { aliasMatch: true, rerankerScore: 0.4 },
+        },
+      },
+      {
+        node,
+        score: 0.9,
+        observations: {
+          providers: ["vector", "lexical"],
+          query: { exactMatch: true, rerankerScore: 0.8 },
+        },
+      },
+    ]);
+
+    expect(fused).toEqual([
+      {
+        node,
+        score: 0.9,
+        observations: {
+          fallback: false,
+          providers: ["fallback", "lexical", "vector"],
+          query: {
+            exactMatch: true,
+            aliasMatch: true,
+            rerankerScore: 0.8,
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/core/tests/traversal-scoring.test.ts
+++ b/packages/core/tests/traversal-scoring.test.ts
@@ -1,0 +1,534 @@
+import { describe, expect, it } from "vitest";
+import {
+  BalancedTraversalScorePolicy,
+  BidirectionalNLayerRetriever,
+  CalibratedTraversalScorePolicy,
+  DEFAULT_CALIBRATED_SCORING_PROFILE,
+  type Principal,
+  type SearchGraphPort,
+  type TraversalScoringProfile,
+  scoringProfileDigest,
+} from "../src/index.js";
+
+const principal: Principal = {
+  organizationId: "acme",
+  subjectId: "user:1",
+  groupIds: ["engineering"],
+};
+
+describe("traversal scoring profiles", () => {
+  it("keeps legacy-v1 scoring mathematically compatible", () => {
+    const policy = new BalancedTraversalScorePolicy();
+    const seed = policy.seedScore({ node: { kind: "chunk", id: "c1" }, score: 0.9 });
+    const edge = policy.edgeScore(
+      seed,
+      {
+        from: { kind: "chunk", id: "c1" },
+        to: { kind: "fact", id: "f1" },
+        operation: "lift",
+        confidence: 0.7,
+        queryRelevance: 0.8,
+        evidenceSupport: 0.8,
+      },
+      2,
+    );
+    const evidence = policy.evidenceScore(edge, {
+      evidenceId: "e1",
+      chunkId: "c1",
+      resourceId: "r1",
+      text: "answer",
+      score: 0.6,
+    });
+
+    expect(edge).toBeCloseTo(0.9 * 0.7 * 0.9 * 0.92 ** 2);
+    expect(evidence).toBeCloseTo(edge * 0.6);
+  });
+
+  it("produces a stable digest independent of object key insertion order", () => {
+    const profile = DEFAULT_CALIBRATED_SCORING_PROFILE;
+    const reordered = {
+      version: profile.version,
+      id: profile.id,
+      featureSchemaVersion: profile.featureSchemaVersion,
+      evidence: { ...profile.evidence },
+      supportEncoding: { ...profile.supportEncoding },
+      edge: { ...profile.edge },
+      seed: { ...profile.seed },
+      description: profile.description,
+    } as TraversalScoringProfile;
+
+    expect(scoringProfileDigest(reordered)).toBe(scoringProfileDigest(profile));
+  });
+
+  it("accepts later profile versions and rejects incomplete profile payloads", () => {
+    expect(
+      () =>
+        new CalibratedTraversalScorePolicy({
+          ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+          version: 2,
+        }),
+    ).not.toThrow();
+    expect(
+      () =>
+        new CalibratedTraversalScorePolicy({
+          ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+          edge: undefined,
+        } as unknown as TraversalScoringProfile),
+    ).toThrow("profile.edge.hopFactor");
+    expect(
+      () =>
+        new CalibratedTraversalScorePolicy({
+          ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+          hiddenKnob: 0.5,
+        } as TraversalScoringProfile),
+    ).toThrow("profile.hiddenKnob");
+  });
+
+  it.each([
+    {
+      name: "an out-of-range score",
+      profile: {
+        ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+        seed: { ...DEFAULT_CALIBRATED_SCORING_PROFILE.seed, exactMatchScore: 1.01 },
+      },
+      message: "profile.seed.exactMatchScore must be between zero and one",
+    },
+    {
+      name: "a non-finite factor",
+      profile: {
+        ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+        edge: { ...DEFAULT_CALIBRATED_SCORING_PROFILE.edge, hopFactor: Number.NaN },
+      },
+      message: "profile.edge.hopFactor must be finite",
+    },
+    {
+      name: "support weights that do not sum to one",
+      profile: {
+        ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+        supportEncoding: {
+          ...DEFAULT_CALIBRATED_SCORING_PROFILE.supportEncoding,
+          reliabilityWeight: 0.6,
+        },
+      },
+      message: "Support encoding reliability, diversity, and volume weights must sum to one",
+    },
+  ])("rejects $name", ({ profile, message }) => {
+    expect(() => new CalibratedTraversalScorePolicy(profile)).toThrow(message);
+  });
+
+  it("applies one hop factor per edge instead of repeatedly exponentiating total depth", () => {
+    const policy = new CalibratedTraversalScorePolicy();
+    const input = {
+      operation: "ground" as const,
+      fromKind: "resource" as const,
+      toKind: "chunk" as const,
+      observations: { structural: { kind: "deterministic" as const } },
+    };
+
+    expect(policy.edgeScore(1, input, 1).score).toBeCloseTo(policy.edgeScore(1, input, 7).score);
+  });
+
+  it("treats missing optional edge signals as neutral and reports them explicitly", () => {
+    const policy = new CalibratedTraversalScorePolicy();
+    const scored = policy.edgeScore(
+      1,
+      {
+        operation: "ground",
+        fromKind: "resource",
+        toKind: "chunk",
+        observations: { structural: { kind: "deterministic" } },
+      },
+      1,
+    );
+
+    expect(scored.factors.query).toBe(1);
+    expect(scored.factors.support).toBe(1);
+    expect(scored.missingSignals).toEqual(["edge.query", "edge.support"]);
+    expect(scored.observations).not.toMatchObject({ query: 0.8, support: 0.8 });
+  });
+
+  it("treats explicitly inapplicable evidence signals as neutral without reporting them missing", () => {
+    const scored = new CalibratedTraversalScorePolicy().evidenceScore(0.8, {
+      factStatus: "active",
+      observations: {
+        origin: "curated",
+        supportApplicability: "not-applicable",
+        confidenceApplicability: "not-applicable",
+        freshnessApplicability: "not-applicable",
+      },
+    });
+
+    expect(scored.score).toBeCloseTo(0.8);
+    expect(scored.factors).toMatchObject({ support: 1, confidence: 1, freshness: 1 });
+    expect(scored.missingSignals).toEqual([]);
+    expect(scored.observations).toMatchObject({
+      supportApplicability: "not-applicable",
+      confidenceApplicability: "not-applicable",
+      freshnessApplicability: "not-applicable",
+    });
+  });
+
+  it("is monotonic when query match and evidence support improve", () => {
+    const policy = new CalibratedTraversalScorePolicy();
+    const base = {
+      operation: "expand" as const,
+      fromKind: "entity" as const,
+      toKind: "fact" as const,
+      observations: {
+        structural: { kind: "extracted" as const, confidence: 0.9 },
+        query: {
+          lexical: { rank: 8, candidateCount: 10 },
+        },
+        support: {
+          activeEvidenceCount: 1,
+          distinctResourceCount: 1,
+          conflictCount: 1,
+        },
+      },
+    };
+    const stronger = {
+      ...base,
+      observations: {
+        ...base.observations,
+        query: { lexical: { rank: 1, candidateCount: 10 } },
+        support: {
+          activeEvidenceCount: 5,
+          curatedEvidenceCount: 3,
+          distinctResourceCount: 3,
+          conflictCount: 0,
+        },
+      },
+    };
+
+    expect(policy.edgeScore(1, stronger, 1).score).toBeGreaterThan(
+      policy.edgeScore(1, base, 1).score,
+    );
+  });
+
+  it("ranks active, confident, fresh evidence above otherwise equivalent weaker evidence", () => {
+    const policy = new CalibratedTraversalScorePolicy();
+    const score = (factStatus: "active" | "conflict", confidence: number, freshnessDays: number) =>
+      policy.evidenceScore(1, {
+        factStatus,
+        observations: {
+          origin: "curated",
+          confidence,
+          freshnessDays,
+          supportApplicability: "not-applicable",
+        },
+      }).score;
+
+    expect(score("active", 0.8, 0)).toBeGreaterThan(score("conflict", 0.8, 0));
+    expect(score("active", 0.9, 0)).toBeGreaterThan(score("active", 0.2, 0));
+    expect(score("active", 0.8, 0)).toBeGreaterThan(score("active", 0.8, 720));
+  });
+
+  it("puts profile identity, raw factors, and missing signals in retrieval output", async () => {
+    const graph: SearchGraphPort = {
+      async seed() {
+        return [
+          {
+            node: { kind: "chunk", id: "c1" },
+            observations: {
+              providers: ["test-lexical"],
+              query: { lexical: { rank: 1, candidateCount: 2, normalizedScore: 0.9 } },
+            },
+          },
+        ];
+      },
+      async neighbors() {
+        return [];
+      },
+      async evidence() {
+        return [
+          {
+            evidenceId: "e1",
+            chunkId: "c1",
+            resourceId: "r1",
+            text: "answer",
+            factStatus: "active",
+            observations: { origin: "curated", freshnessDays: 2 },
+          },
+        ];
+      },
+    };
+
+    const result = await new BidirectionalNLayerRetriever(
+      graph,
+      new CalibratedTraversalScorePolicy(),
+    ).retrieve({ question: "answer", principal });
+
+    expect(result.trace.scoring.profileId).toBe("calibrated-v2");
+    expect(result.trace.scoring.missingSignals).toEqual([
+      "evidence.confidence",
+      "evidence.support",
+    ]);
+    expect(result.trace.scoring.missingSignalCounts).toEqual({
+      "evidence.confidence": 1,
+      "evidence.support": 1,
+    });
+    expect(result.trace.averageSelectedPathLength).toBe(0);
+    expect(result.trace.seedProviderCounts).toEqual({ "test-lexical": 1 });
+    expect(result.evidence[0]?.scoreBreakdown).toMatchObject({
+      profileId: "calibrated-v2",
+      seed: {
+        observations: {
+          lexical: 1,
+          lexicalRank: 1,
+          lexicalCandidateCount: 2,
+          lexicalNormalizedScore: 0.9,
+        },
+      },
+      evidence: { observations: { origin: "curated", freshnessDays: 2 } },
+    });
+  });
+
+  it("runs a configured shadow frontier without changing active evidence", async () => {
+    const graph: SearchGraphPort = {
+      async seed() {
+        return [
+          {
+            node: { kind: "chunk", id: "c1" },
+            observations: {
+              query: { lexical: { rank: 1, candidateCount: 1 } },
+            },
+          },
+        ];
+      },
+      async neighbors() {
+        return [];
+      },
+      async evidence() {
+        return [
+          {
+            evidenceId: "e1",
+            chunkId: "c1",
+            resourceId: "r1",
+            text: "answer",
+            observations: { origin: "derived", freshnessDays: 0 },
+          },
+        ];
+      },
+    };
+    const active = new CalibratedTraversalScorePolicy();
+    const shadow = new CalibratedTraversalScorePolicy({
+      ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+      id: "shadow-v2",
+      version: 2,
+    });
+    const result = await new BidirectionalNLayerRetriever(graph, {
+      async resolve() {
+        return active;
+      },
+      async resolveShadow() {
+        return shadow;
+      },
+    }).retrieve({ question: "answer", principal });
+
+    expect(result.evidence.map((hit) => hit.evidenceId)).toEqual(["e1"]);
+    expect(result.trace.scoring.shadow).toMatchObject({
+      profileId: "shadow-v2",
+      status: "completed",
+      topKOverlapRatio: 1,
+      normalizedRankDisagreement: 0,
+    });
+  });
+
+  it("does not fail active retrieval when shadow profile resolution fails", async () => {
+    const graph: SearchGraphPort = {
+      async seed() {
+        return [
+          {
+            node: { kind: "chunk", id: "c1" },
+            observations: { query: { exactMatch: true } },
+          },
+        ];
+      },
+      async neighbors() {
+        return [];
+      },
+      async evidence() {
+        return [
+          {
+            evidenceId: "e1",
+            chunkId: "c1",
+            resourceId: "r1",
+            text: "answer",
+            factStatus: "active",
+            observations: { origin: "curated", freshnessDays: 0 },
+          },
+        ];
+      },
+    };
+    const result = await new BidirectionalNLayerRetriever(graph, {
+      async resolve() {
+        return new CalibratedTraversalScorePolicy();
+      },
+      async resolveShadow() {
+        throw new Error("shadow store unavailable");
+      },
+    }).retrieve({ question: "answer", principal });
+
+    expect(result.evidence[0]?.evidenceId).toBe("e1");
+    expect(result.trace.scoring.shadow).toMatchObject({
+      status: "failed",
+      profileId: "unresolved-shadow",
+      errorName: "Error",
+    });
+  });
+
+  it("keeps active evidence when shadow traversal fails and closes the shared session once", async () => {
+    let opened = 0;
+    let closed = 0;
+    let seedCalls = 0;
+    const session = {
+      async close() {
+        closed++;
+      },
+    };
+    const receivedSessions: unknown[] = [];
+    const graph: SearchGraphPort = {
+      async openSession() {
+        opened++;
+        return session;
+      },
+      async seed(_question, _principal, receivedSession) {
+        receivedSessions.push(receivedSession);
+        seedCalls++;
+        if (seedCalls === 2) throw new Error("shadow traversal failed");
+        return [
+          {
+            node: { kind: "chunk", id: "c1" },
+            observations: { query: { exactMatch: true } },
+          },
+        ];
+      },
+      async neighbors() {
+        return [];
+      },
+      async evidence() {
+        return [
+          {
+            evidenceId: "e1",
+            chunkId: "c1",
+            resourceId: "r1",
+            text: "active answer",
+            observations: {
+              origin: "curated",
+              supportApplicability: "not-applicable",
+              confidenceApplicability: "not-applicable",
+              freshnessApplicability: "not-applicable",
+            },
+          },
+        ];
+      },
+    };
+    const result = await new BidirectionalNLayerRetriever(graph, {
+      async resolve() {
+        return new CalibratedTraversalScorePolicy();
+      },
+      async resolveShadow() {
+        return new CalibratedTraversalScorePolicy({
+          ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+          id: "shadow-failure",
+          version: 2,
+        });
+      },
+    }).retrieve({ question: "answer", principal });
+
+    expect(result.evidence.map((hit) => hit.evidenceId)).toEqual(["e1"]);
+    expect(result.trace.scoring.shadow).toMatchObject({
+      profileId: "shadow-failure",
+      status: "failed",
+      errorName: "Error",
+    });
+    expect(opened).toBe(1);
+    expect(closed).toBe(1);
+    expect(receivedSessions).toEqual([session, session]);
+  });
+
+  it("reports shadow rank disagreement without replacing the active ordering", async () => {
+    const graph: SearchGraphPort = {
+      async seed() {
+        return [
+          {
+            node: { kind: "chunk", id: "lexical-first" },
+            observations: {
+              query: {
+                lexical: { rank: 1, candidateCount: 2 },
+                vector: { rank: 2, candidateCount: 2 },
+              },
+            },
+          },
+          {
+            node: { kind: "chunk", id: "vector-first" },
+            observations: {
+              query: {
+                lexical: { rank: 2, candidateCount: 2 },
+                vector: { rank: 1, candidateCount: 2 },
+              },
+            },
+          },
+        ];
+      },
+      async neighbors() {
+        return [];
+      },
+      async evidence(node) {
+        return [
+          {
+            evidenceId: `evidence:${node.id}`,
+            chunkId: node.id,
+            resourceId: `resource:${node.id}`,
+            text: node.id,
+            observations: {
+              origin: "curated",
+              supportApplicability: "not-applicable",
+              confidenceApplicability: "not-applicable",
+              freshnessApplicability: "not-applicable",
+            },
+          },
+        ];
+      },
+    };
+    const lexicalProfile = {
+      ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+      id: "lexical-active",
+      version: 2,
+      seed: {
+        ...DEFAULT_CALIBRATED_SCORING_PROFILE.seed,
+        lexicalWeight: 10,
+        vectorWeight: 1,
+      },
+    };
+    const vectorProfile = {
+      ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+      id: "vector-shadow",
+      version: 2,
+      seed: {
+        ...DEFAULT_CALIBRATED_SCORING_PROFILE.seed,
+        lexicalWeight: 1,
+        vectorWeight: 10,
+      },
+    };
+    const result = await new BidirectionalNLayerRetriever(graph, {
+      async resolve() {
+        return new CalibratedTraversalScorePolicy(lexicalProfile);
+      },
+      async resolveShadow() {
+        return new CalibratedTraversalScorePolicy(vectorProfile);
+      },
+    }).retrieve({ question: "answer", principal });
+
+    expect(result.evidence.map((hit) => hit.evidenceId)).toEqual([
+      "evidence:lexical-first",
+      "evidence:vector-first",
+    ]);
+    expect(result.trace.scoring.shadow).toMatchObject({
+      profileId: "vector-shadow",
+      status: "completed",
+      topKOverlapRatio: 1,
+      normalizedRankDisagreement: 0.5,
+    });
+  });
+});

--- a/packages/postgres/migrations/0002_scoring_profiles_and_observations.sql
+++ b/packages/postgres/migrations/0002_scoring_profiles_and_observations.sql
@@ -1,0 +1,162 @@
+ALTER TABLE kontext_resource_ontology_links
+  ADD COLUMN IF NOT EXISTS origin text,
+  ADD COLUMN IF NOT EXISTS confidence real,
+  ADD COLUMN IF NOT EXISTS created_at timestamptz;
+
+ALTER TABLE kontext_chunk_ontology_links
+  ADD COLUMN IF NOT EXISTS origin text,
+  ADD COLUMN IF NOT EXISTS confidence real,
+  ADD COLUMN IF NOT EXISTS created_at timestamptz;
+
+ALTER TABLE kontext_entity_mentions
+  ADD COLUMN IF NOT EXISTS origin text,
+  ADD COLUMN IF NOT EXISTS extraction_confidence real,
+  ADD COLUMN IF NOT EXISTS extractor_version text,
+  ADD COLUMN IF NOT EXISTS observed_at timestamptz;
+
+ALTER TABLE kontext_facts
+  ADD COLUMN IF NOT EXISTS origin text,
+  ADD COLUMN IF NOT EXISTS extraction_confidence real,
+  ADD COLUMN IF NOT EXISTS extractor_version text,
+  ADD COLUMN IF NOT EXISTS observed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS verified_at timestamptz;
+
+ALTER TABLE kontext_evidence
+  ADD COLUMN IF NOT EXISTS confidence real,
+  ADD COLUMN IF NOT EXISTS observed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS verified_at timestamptz;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_resource_links_origin_values'
+  ) THEN
+    ALTER TABLE kontext_resource_ontology_links
+      ADD CONSTRAINT kontext_resource_links_origin_values
+      CHECK (origin IS NULL OR origin IN ('manual', 'automatic', 'deterministic'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_chunk_links_origin_values'
+  ) THEN
+    ALTER TABLE kontext_chunk_ontology_links
+      ADD CONSTRAINT kontext_chunk_links_origin_values
+      CHECK (origin IS NULL OR origin IN ('manual', 'automatic', 'deterministic'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_mentions_origin_values'
+  ) THEN
+    ALTER TABLE kontext_entity_mentions
+      ADD CONSTRAINT kontext_mentions_origin_values
+      CHECK (origin IS NULL OR origin IN ('derived', 'curated'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_facts_origin_values'
+  ) THEN
+    ALTER TABLE kontext_facts
+      ADD CONSTRAINT kontext_facts_origin_values
+      CHECK (origin IS NULL OR origin IN ('derived', 'curated'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_resource_links_confidence_range'
+  ) THEN
+    ALTER TABLE kontext_resource_ontology_links
+      ADD CONSTRAINT kontext_resource_links_confidence_range
+      CHECK (confidence IS NULL OR confidence BETWEEN 0 AND 1);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_chunk_links_confidence_range'
+  ) THEN
+    ALTER TABLE kontext_chunk_ontology_links
+      ADD CONSTRAINT kontext_chunk_links_confidence_range
+      CHECK (confidence IS NULL OR confidence BETWEEN 0 AND 1);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_mentions_confidence_range'
+  ) THEN
+    ALTER TABLE kontext_entity_mentions
+      ADD CONSTRAINT kontext_mentions_confidence_range
+      CHECK (extraction_confidence IS NULL OR extraction_confidence BETWEEN 0 AND 1);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_facts_confidence_range'
+  ) THEN
+    ALTER TABLE kontext_facts
+      ADD CONSTRAINT kontext_facts_confidence_range
+      CHECK (extraction_confidence IS NULL OR extraction_confidence BETWEEN 0 AND 1);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_evidence_confidence_range'
+  ) THEN
+    ALTER TABLE kontext_evidence
+      ADD CONSTRAINT kontext_evidence_confidence_range
+      CHECK (confidence IS NULL OR confidence BETWEEN 0 AND 1);
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS kontext_scoring_profiles (
+  organization_id text NOT NULL REFERENCES kontext_organizations(organization_id),
+  profile_id text NOT NULL,
+  version integer NOT NULL CHECK (version > 0),
+  feature_schema_version text NOT NULL,
+  profile_digest text NOT NULL,
+  profile_data jsonb NOT NULL,
+  evaluation_summary jsonb,
+  status text NOT NULL CHECK (status IN ('staged', 'active', 'retired', 'failed')),
+  failure text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (organization_id, profile_digest),
+  UNIQUE (organization_id, profile_id, version)
+);
+
+ALTER TABLE kontext_scoring_profiles
+  ADD COLUMN IF NOT EXISTS feature_schema_version text,
+  ADD COLUMN IF NOT EXISTS evaluation_summary jsonb;
+
+ALTER TABLE kontext_organization_runtime
+  ADD COLUMN IF NOT EXISTS active_scoring_profile_digest text,
+  ADD COLUMN IF NOT EXISTS shadow_scoring_profile_digest text,
+  ADD COLUMN IF NOT EXISTS scoring_canary_percent smallint NOT NULL DEFAULT 100;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_runtime_scoring_canary_range'
+  ) THEN
+    ALTER TABLE kontext_organization_runtime
+      ADD CONSTRAINT kontext_runtime_scoring_canary_range
+      CHECK (scoring_canary_percent BETWEEN 0 AND 100);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_runtime_active_scoring_profile_fk'
+  ) THEN
+    ALTER TABLE kontext_organization_runtime
+      ADD CONSTRAINT kontext_runtime_active_scoring_profile_fk
+      FOREIGN KEY (organization_id, active_scoring_profile_digest)
+      REFERENCES kontext_scoring_profiles(organization_id, profile_digest);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'kontext_runtime_shadow_scoring_profile_fk'
+  ) THEN
+    ALTER TABLE kontext_organization_runtime
+      ADD CONSTRAINT kontext_runtime_shadow_scoring_profile_fk
+      FOREIGN KEY (organization_id, shadow_scoring_profile_digest)
+      REFERENCES kontext_scoring_profiles(organization_id, profile_digest);
+  END IF;
+END $$;
+
+ALTER TABLE kontext_scoring_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE kontext_scoring_profiles FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = current_schema()
+      AND tablename = 'kontext_scoring_profiles'
+      AND policyname = 'kontext_organization_isolation'
+  ) THEN
+    CREATE POLICY kontext_organization_isolation ON kontext_scoring_profiles
+      USING (organization_id = current_setting('kontext.organization_id', true))
+      WITH CHECK (organization_id = current_setting('kontext.organization_id', true));
+  END IF;
+END $$;

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -6,4 +6,5 @@ export * from "./postgres-ontology-proposal-queue.js";
 export * from "./postgres-knowledge-search-graph.js";
 export * from "./postgres-runtime.js";
 export * from "./postgres-chunk-vector-index.js";
+export * from "./postgres-scoring-profiles.js";
 export { runPostgresSearchRead } from "./postgres-search-session.js";

--- a/packages/postgres/src/migrate.ts
+++ b/packages/postgres/src/migrate.ts
@@ -2,7 +2,12 @@ import { readFile } from "node:fs/promises";
 import type { Pool } from "pg";
 
 export async function migratePostgres(pool: Pool): Promise<void> {
-  const migrationUrl = new URL("../migrations/0001_knowledge_graph.sql", import.meta.url);
-  const sql = await readFile(migrationUrl, "utf8");
-  await pool.query(sql);
+  for (const filename of [
+    "0001_knowledge_graph.sql",
+    "0002_scoring_profiles_and_observations.sql",
+  ]) {
+    const migrationUrl = new URL(`../migrations/${filename}`, import.meta.url);
+    const sql = await readFile(migrationUrl, "utf8");
+    await pool.query(sql);
+  }
 }

--- a/packages/postgres/src/postgres-chunk-vector-index.ts
+++ b/packages/postgres/src/postgres-chunk-vector-index.ts
@@ -42,14 +42,20 @@ export class PostgresChunkVectorIndex implements SearchSeedProvider {
     this.assertDimensions(embedding);
     const search = async (client: PoolClient): Promise<readonly SearchSeed[]> => {
       const result = await client.query(
-        `SELECT c.chunk_id, 1 - (c.embedding <=> $4::vector) AS score
-         FROM kontext_chunks c
-         JOIN kontext_resources r
-           ON r.organization_id = c.organization_id AND r.resource_id = c.resource_id
-         WHERE c.organization_id = $1 AND c.status = 'active' AND r.status = 'active'
-           AND c.embedding IS NOT NULL
-           AND ${aclPredicate("c")} AND ${aclPredicate("r")}
-         ORDER BY c.embedding <=> $4::vector
+        `WITH matches AS (
+           SELECT c.chunk_id, 1 - (c.embedding <=> $4::vector) AS similarity
+           FROM kontext_chunks c
+           JOIN kontext_resources r
+             ON r.organization_id = c.organization_id AND r.resource_id = c.resource_id
+           WHERE c.organization_id = $1 AND c.status = 'active' AND r.status = 'active'
+             AND c.embedding IS NOT NULL
+             AND ${aclPredicate("c")} AND ${aclPredicate("r")}
+         )
+         SELECT chunk_id, similarity,
+                row_number() OVER (ORDER BY similarity DESC, chunk_id) AS retrieval_rank,
+                count(*) OVER () AS candidate_count
+         FROM matches
+         ORDER BY similarity DESC, chunk_id
          LIMIT $5`,
         [
           principal.organizationId,
@@ -61,7 +67,16 @@ export class PostgresChunkVectorIndex implements SearchSeedProvider {
       );
       return result.rows.map((row) => ({
         node: { kind: "chunk" as const, id: String(row.chunk_id) },
-        score: Math.max(0, Math.min(1, Number(row.score))),
+        observations: {
+          providers: ["postgres-chunk-vector"],
+          query: {
+            vector: {
+              rank: finitePositiveInteger(row.retrieval_rank),
+              candidateCount: finitePositiveInteger(row.candidate_count),
+              normalizedScore: normalizedSimilarity(row.similarity),
+            },
+          },
+        },
       }));
     };
     return runPostgresSearchRead(this.pool, principal.organizationId, session, search);
@@ -81,4 +96,15 @@ export class PostgresChunkVectorIndex implements SearchSeedProvider {
 
 function vectorLiteral(values: readonly number[]): string {
   return `[${values.join(",")}]`;
+}
+
+function finitePositiveInteger(value: unknown): number {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? Math.max(1, Math.floor(numeric)) : 1;
+}
+
+function normalizedSimilarity(value: unknown): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  return Math.max(0, Math.min(1, numeric));
 }

--- a/packages/postgres/src/postgres-knowledge-graph.ts
+++ b/packages/postgres/src/postgres-knowledge-graph.ts
@@ -11,6 +11,7 @@ import type {
   FactRecord,
   KnowledgeGraphRepository,
   KnowledgeGraphUnitOfWork,
+  OntologyLinkRecord,
   Principal,
   ResourceRecord,
   ResourceSource,
@@ -174,6 +175,7 @@ class PostgresKnowledgeGraphUnitOfWork implements KnowledgeGraphUnitOfWork {
       resource.organizationId,
       resource.resourceId,
       resource.ontologyNodeIds,
+      resource.ontologyLinks,
     );
   }
 
@@ -226,6 +228,7 @@ class PostgresKnowledgeGraphUnitOfWork implements KnowledgeGraphUnitOfWork {
       chunk.organizationId,
       chunk.chunkId,
       chunk.ontologyNodeIds,
+      chunk.ontologyLinks,
     );
   }
 
@@ -265,7 +268,8 @@ class PostgresKnowledgeGraphUnitOfWork implements KnowledgeGraphUnitOfWork {
 
   async listEntityMentions(resourceId: string): Promise<readonly EntityMentionRecord[]> {
     const result = await this.client.query(
-      `SELECT organization_id, entity_id, resource_id, chunk_id, status
+      `SELECT organization_id, entity_id, resource_id, chunk_id, status,
+              extraction_confidence, extractor_version, origin, observed_at
        FROM kontext_entity_mentions
        WHERE organization_id = $1 AND resource_id = $2`,
       [this.organizationId, resourceId],
@@ -277,24 +281,34 @@ class PostgresKnowledgeGraphUnitOfWork implements KnowledgeGraphUnitOfWork {
     assertOrganization(this.organizationId, mention.organizationId);
     await this.client.query(
       `INSERT INTO kontext_entity_mentions (
-         organization_id, entity_id, resource_id, chunk_id, status
-       ) VALUES ($1,$2,$3,$4,$5)
+         organization_id, entity_id, resource_id, chunk_id, status,
+         extraction_confidence, extractor_version, origin, observed_at
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
        ON CONFLICT (organization_id, entity_id, chunk_id) DO UPDATE SET
          resource_id = EXCLUDED.resource_id,
-         status = EXCLUDED.status`,
+         status = EXCLUDED.status,
+         extraction_confidence = EXCLUDED.extraction_confidence,
+         extractor_version = EXCLUDED.extractor_version,
+         origin = EXCLUDED.origin,
+         observed_at = EXCLUDED.observed_at`,
       [
         mention.organizationId,
         mention.entityId,
         mention.resourceId,
         mention.chunkId,
         mention.status,
+        mention.extractionConfidence ?? null,
+        mention.extractorVersion ?? null,
+        mention.origin ?? null,
+        mention.observedAt ?? null,
       ],
     );
   }
 
   async getFact(factKey: string): Promise<FactRecord | null> {
     const result = await this.client.query(
-      `SELECT organization_id, fact_key, subject, predicate, object, single_value, status, updated_at
+      `SELECT organization_id, fact_key, subject, predicate, object, single_value, status,
+              updated_at, extraction_confidence, extractor_version, origin, observed_at, verified_at
        FROM kontext_facts
        WHERE organization_id = $1 AND fact_key = $2`,
       [this.organizationId, factKey],
@@ -304,7 +318,8 @@ class PostgresKnowledgeGraphUnitOfWork implements KnowledgeGraphUnitOfWork {
 
   async listFacts(): Promise<readonly FactRecord[]> {
     const result = await this.client.query(
-      `SELECT organization_id, fact_key, subject, predicate, object, single_value, status, updated_at
+      `SELECT organization_id, fact_key, subject, predicate, object, single_value, status,
+              updated_at, extraction_confidence, extractor_version, origin, observed_at, verified_at
        FROM kontext_facts
        WHERE organization_id = $1`,
       [this.organizationId],
@@ -316,15 +331,21 @@ class PostgresKnowledgeGraphUnitOfWork implements KnowledgeGraphUnitOfWork {
     assertOrganization(this.organizationId, fact.organizationId);
     await this.client.query(
       `INSERT INTO kontext_facts (
-         organization_id, fact_key, subject, predicate, object, single_value, status, updated_at
-       ) VALUES ($1,$2,$3::jsonb,$4,$5::jsonb,$6,$7,$8)
+         organization_id, fact_key, subject, predicate, object, single_value, status, updated_at,
+         extraction_confidence, extractor_version, origin, observed_at, verified_at
+       ) VALUES ($1,$2,$3::jsonb,$4,$5::jsonb,$6,$7,$8,$9,$10,$11,$12,$13)
        ON CONFLICT (organization_id, fact_key) DO UPDATE SET
          subject = EXCLUDED.subject,
          predicate = EXCLUDED.predicate,
          object = EXCLUDED.object,
          single_value = EXCLUDED.single_value,
          status = EXCLUDED.status,
-         updated_at = EXCLUDED.updated_at`,
+         updated_at = EXCLUDED.updated_at,
+         extraction_confidence = EXCLUDED.extraction_confidence,
+         extractor_version = EXCLUDED.extractor_version,
+         origin = EXCLUDED.origin,
+         observed_at = EXCLUDED.observed_at,
+         verified_at = EXCLUDED.verified_at`,
       [
         fact.organizationId,
         fact.factKey,
@@ -334,13 +355,19 @@ class PostgresKnowledgeGraphUnitOfWork implements KnowledgeGraphUnitOfWork {
         fact.singleValue,
         fact.status,
         fact.updatedAt,
+        fact.extractionConfidence ?? null,
+        fact.extractorVersion ?? null,
+        fact.origin ?? null,
+        fact.observedAt ?? null,
+        fact.verifiedAt ?? null,
       ],
     );
   }
 
   async listEvidenceForResource(resourceId: string): Promise<readonly EvidenceRecord[]> {
     const result = await this.client.query(
-      `SELECT organization_id, evidence_id, fact_key, resource_id, chunk_id, acl, origin, status
+      `SELECT organization_id, evidence_id, fact_key, resource_id, chunk_id, acl, origin, status,
+              confidence, observed_at, verified_at
        FROM kontext_evidence
        WHERE organization_id = $1 AND resource_id = $2`,
       [this.organizationId, resourceId],
@@ -350,7 +377,8 @@ class PostgresKnowledgeGraphUnitOfWork implements KnowledgeGraphUnitOfWork {
 
   async listEvidenceForFact(factKey: string): Promise<readonly EvidenceRecord[]> {
     const result = await this.client.query(
-      `SELECT organization_id, evidence_id, fact_key, resource_id, chunk_id, acl, origin, status
+      `SELECT organization_id, evidence_id, fact_key, resource_id, chunk_id, acl, origin, status,
+              confidence, observed_at, verified_at
        FROM kontext_evidence
        WHERE organization_id = $1 AND fact_key = $2`,
       [this.organizationId, factKey],
@@ -362,15 +390,19 @@ class PostgresKnowledgeGraphUnitOfWork implements KnowledgeGraphUnitOfWork {
     assertOrganization(this.organizationId, evidence.organizationId);
     await this.client.query(
       `INSERT INTO kontext_evidence (
-         organization_id, evidence_id, fact_key, resource_id, chunk_id, acl, origin, status
-       ) VALUES ($1,$2,$3,$4,$5,$6::jsonb,$7,$8)
+         organization_id, evidence_id, fact_key, resource_id, chunk_id, acl, origin, status,
+         confidence, observed_at, verified_at
+       ) VALUES ($1,$2,$3,$4,$5,$6::jsonb,$7,$8,$9,$10,$11)
        ON CONFLICT (organization_id, evidence_id) DO UPDATE SET
          fact_key = EXCLUDED.fact_key,
          resource_id = EXCLUDED.resource_id,
          chunk_id = EXCLUDED.chunk_id,
          acl = EXCLUDED.acl,
          origin = EXCLUDED.origin,
-         status = EXCLUDED.status`,
+         status = EXCLUDED.status,
+         confidence = EXCLUDED.confidence,
+         observed_at = EXCLUDED.observed_at,
+         verified_at = EXCLUDED.verified_at`,
       [
         evidence.organizationId,
         evidence.evidenceId,
@@ -380,6 +412,9 @@ class PostgresKnowledgeGraphUnitOfWork implements KnowledgeGraphUnitOfWork {
         JSON.stringify(evidence.acl),
         evidence.origin,
         evidence.status,
+        evidence.confidence ?? null,
+        evidence.observedAt ?? null,
+        evidence.verifiedAt ?? null,
       ],
     );
   }
@@ -509,7 +544,16 @@ function resourceSelectSql(): string {
   return `SELECT r.*,
     ARRAY(SELECT ontology_node_id FROM kontext_resource_ontology_links l
           WHERE l.organization_id = r.organization_id AND l.resource_id = r.resource_id
-          ORDER BY ontology_node_id) AS ontology_node_ids
+          ORDER BY ontology_node_id) AS ontology_node_ids,
+    COALESCE((SELECT jsonb_agg(jsonb_build_object(
+      'ontologyNodeId', ontology_node_id,
+      'origin', origin,
+      'confidence', confidence,
+      'createdAt', created_at
+    ) ORDER BY ontology_node_id)
+      FROM kontext_resource_ontology_links l
+      WHERE l.organization_id = r.organization_id AND l.resource_id = r.resource_id), '[]'::jsonb)
+      AS ontology_links
     FROM kontext_resources r`;
 }
 
@@ -517,7 +561,16 @@ function chunkSelectSql(): string {
   return `SELECT c.*,
     ARRAY(SELECT ontology_node_id FROM kontext_chunk_ontology_links l
           WHERE l.organization_id = c.organization_id AND l.chunk_id = c.chunk_id
-          ORDER BY ontology_node_id) AS ontology_node_ids
+          ORDER BY ontology_node_id) AS ontology_node_ids,
+    COALESCE((SELECT jsonb_agg(jsonb_build_object(
+      'ontologyNodeId', ontology_node_id,
+      'origin', origin,
+      'confidence', confidence,
+      'createdAt', created_at
+    ) ORDER BY ontology_node_id)
+      FROM kontext_chunk_ontology_links l
+      WHERE l.organization_id = c.organization_id AND l.chunk_id = c.chunk_id), '[]'::jsonb)
+      AS ontology_links
     FROM kontext_chunks c`;
 }
 
@@ -528,13 +581,40 @@ async function insertOntologyLinks(
   organizationId: string,
   ownerId: string,
   ontologyNodeIds: readonly string[],
+  ontologyLinks: ResourceRecord["ontologyLinks"] | ChunkRecord["ontologyLinks"],
 ): Promise<void> {
-  if (ontologyNodeIds.length === 0) return;
+  const metadata = new Map((ontologyLinks ?? []).map((link) => [link.ontologyNodeId, link]));
+  const links = [...new Set(ontologyNodeIds)].map((ontologyNodeId) => ({
+    ontologyNodeId,
+    origin: metadata.get(ontologyNodeId)?.origin ?? null,
+    confidence: metadata.get(ontologyNodeId)?.confidence ?? null,
+    createdAt: metadata.get(ontologyNodeId)?.createdAt ?? null,
+  }));
+  if (links.length === 0) return;
   await client.query(
-    `INSERT INTO ${table} (organization_id, ${ownerColumn}, ontology_node_id)
-     SELECT $1, $2, unnest($3::text[])
-     ON CONFLICT DO NOTHING`,
-    [organizationId, ownerId, [...new Set(ontologyNodeIds)]],
+    `INSERT INTO ${table} (
+       organization_id, ${ownerColumn}, ontology_node_id, origin, confidence, created_at
+     )
+     SELECT $1, $2, item.ontology_node_id, item.origin, item.confidence, item.created_at
+     FROM jsonb_to_recordset($3::jsonb) AS item(
+       ontology_node_id text, origin text, confidence real, created_at timestamptz
+     )
+     ON CONFLICT (organization_id, ${ownerColumn}, ontology_node_id) DO UPDATE SET
+       origin = EXCLUDED.origin,
+       confidence = EXCLUDED.confidence,
+       created_at = EXCLUDED.created_at`,
+    [
+      organizationId,
+      ownerId,
+      JSON.stringify(
+        links.map((link) => ({
+          ontology_node_id: link.ontologyNodeId,
+          origin: link.origin,
+          confidence: link.confidence,
+          created_at: link.createdAt,
+        })),
+      ),
+    ],
   );
 }
 
@@ -552,6 +632,7 @@ function mapResource(row: QueryResultRow): ResourceRecord {
     contentObjectKey: String(row.content_object_key),
     acl: row.acl as AccessControlList,
     ontologyNodeIds: (row.ontology_node_ids ?? []) as string[],
+    ontologyLinks: mapOntologyLinks(row.ontology_links),
     status: row.status as ResourceRecord["status"],
     updatedAt: toIsoString(row.updated_at),
   };
@@ -568,6 +649,7 @@ function mapChunk(row: QueryResultRow): ChunkRecord {
     position: Number(row.position),
     acl: row.acl as AccessControlList,
     ontologyNodeIds: (row.ontology_node_ids ?? []) as string[],
+    ontologyLinks: mapOntologyLinks(row.ontology_links),
     status: row.status as ChunkRecord["status"],
   };
 }
@@ -579,6 +661,22 @@ function mapEntityMention(row: QueryResultRow): EntityMentionRecord {
     resourceId: String(row.resource_id),
     chunkId: String(row.chunk_id),
     status: row.status as EntityMentionRecord["status"],
+    extractionConfidence:
+      row.extraction_confidence === null || row.extraction_confidence === undefined
+        ? undefined
+        : Number(row.extraction_confidence),
+    extractorVersion:
+      row.extractor_version === null || row.extractor_version === undefined
+        ? undefined
+        : String(row.extractor_version),
+    origin:
+      row.origin === null || row.origin === undefined
+        ? undefined
+        : (row.origin as EntityMentionRecord["origin"]),
+    observedAt:
+      row.observed_at === null || row.observed_at === undefined
+        ? undefined
+        : toIsoString(row.observed_at),
   };
 }
 
@@ -604,6 +702,26 @@ function mapFact(row: QueryResultRow): FactRecord {
     singleValue: Boolean(row.single_value),
     status: row.status as FactRecord["status"],
     updatedAt: toIsoString(row.updated_at),
+    extractionConfidence:
+      row.extraction_confidence === null || row.extraction_confidence === undefined
+        ? undefined
+        : Number(row.extraction_confidence),
+    extractorVersion:
+      row.extractor_version === null || row.extractor_version === undefined
+        ? undefined
+        : String(row.extractor_version),
+    origin:
+      row.origin === null || row.origin === undefined
+        ? undefined
+        : (row.origin as FactRecord["origin"]),
+    observedAt:
+      row.observed_at === null || row.observed_at === undefined
+        ? undefined
+        : toIsoString(row.observed_at),
+    verifiedAt:
+      row.verified_at === null || row.verified_at === undefined
+        ? undefined
+        : toIsoString(row.verified_at),
   };
 }
 
@@ -617,7 +735,40 @@ function mapEvidence(row: QueryResultRow): EvidenceRecord {
     acl: row.acl as AccessControlList,
     origin: row.origin as EvidenceRecord["origin"],
     status: row.status as EvidenceRecord["status"],
+    confidence:
+      row.confidence === null || row.confidence === undefined ? undefined : Number(row.confidence),
+    observedAt:
+      row.observed_at === null || row.observed_at === undefined
+        ? undefined
+        : toIsoString(row.observed_at),
+    verifiedAt:
+      row.verified_at === null || row.verified_at === undefined
+        ? undefined
+        : toIsoString(row.verified_at),
   };
+}
+
+function mapOntologyLinks(value: unknown): OntologyLinkRecord[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const row = item as Record<string, unknown>;
+    if (typeof row.ontologyNodeId !== "string") return [];
+    return [
+      {
+        ontologyNodeId: row.ontologyNodeId,
+        ...(row.origin === null || row.origin === undefined
+          ? {}
+          : { origin: row.origin as OntologyLinkRecord["origin"] }),
+        ...(row.confidence === null || row.confidence === undefined
+          ? {}
+          : { confidence: Number(row.confidence) }),
+        ...(row.createdAt === null || row.createdAt === undefined
+          ? {}
+          : { createdAt: toIsoString(row.createdAt) }),
+      },
+    ];
+  });
 }
 
 function mapFactEvent(row: QueryResultRow): FactEvent {

--- a/packages/postgres/src/postgres-knowledge-search-graph.ts
+++ b/packages/postgres/src/postgres-knowledge-search-graph.ts
@@ -3,11 +3,13 @@ import type {
   Principal,
   ResourceContentStore,
   SearchEdge,
+  SearchEdgeObservations,
   SearchGraphPort,
   SearchGraphSession,
   SearchNode,
   SearchSeed,
 } from "@kontext-brain/core";
+import { fuseSearchSeeds } from "@kontext-brain/core";
 import type { Pool, PoolClient, QueryResultRow } from "pg";
 import { PostgresSearchSession, runPostgresSearchRead } from "./postgres-search-session.js";
 import { aclPredicate } from "./postgres-value-utils.js";
@@ -77,13 +79,7 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
       additional.push(await provider.seed(question, principal, session));
     }
     const databaseSeeds = await this.databaseSeeds(question, principal, session);
-    const best = new Map<string, SearchSeed>();
-    for (const seed of [databaseSeeds, ...additional].flat()) {
-      const key = nodeKey(seed.node);
-      const previous = best.get(key);
-      if (!previous || seed.score > previous.score) best.set(key, seed);
-    }
-    return Array.from(best.values());
+    return fuseSearchSeeds([databaseSeeds, ...additional].flat());
   }
 
   async neighbors(
@@ -117,8 +113,10 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
     if (node.kind !== "chunk") return [];
     const rows = await this.runRead(principal, session, async (client) => {
       const result = await client.query(
-        `SELECT e.evidence_id, e.fact_key, e.resource_id, e.chunk_id,
-                  f.status AS fact_status, c.source_chunk_id, c.content_object_key
+        `SELECT e.evidence_id, e.fact_key, e.resource_id, e.chunk_id, e.origin,
+                  e.confidence, e.observed_at, e.verified_at,
+                  f.status AS fact_status, c.source_chunk_id, c.content_object_key,
+                  r.updated_at AS resource_updated_at
            FROM kontext_evidence e
            LEFT JOIN kontext_facts f
              ON f.organization_id = e.organization_id AND f.fact_key = e.fact_key
@@ -141,6 +139,11 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
       const content = await this.contentStore.get(String(row.content_object_key));
       const text = content?.chunks[String(row.source_chunk_id)];
       if (text === undefined) continue;
+      const freshnessDate = row.verified_at ?? row.observed_at ?? row.resource_updated_at;
+      const freshnessDays =
+        freshnessDate === null || freshnessDate === undefined
+          ? undefined
+          : ageInDays(freshnessDate);
       hits.push({
         evidenceId: String(row.evidence_id),
         factKey: row.fact_key === null ? undefined : String(row.fact_key),
@@ -149,7 +152,21 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
         resourceId: String(row.resource_id),
         chunkId: String(row.chunk_id),
         text,
-        score: row.fact_status === "conflict" ? 0.6 : row.fact_key === null ? 0.75 : 1,
+        observations: {
+          origin: row.origin as "curated" | "derived",
+          ...(row.confidence === null || row.confidence === undefined
+            ? {}
+            : { confidence: Number(row.confidence) }),
+          ...(freshnessDays === undefined ? {} : { freshnessDays }),
+          support: {
+            activeEvidenceCount: 1,
+            curatedEvidenceCount: row.origin === "curated" ? 1 : 0,
+            derivedEvidenceCount: row.origin === "derived" ? 1 : 0,
+            distinctResourceCount: 1,
+            conflictCount: row.fact_status === "conflict" ? 1 : 0,
+            staleEvidenceCount: 0,
+          },
+        },
       });
     }
     return hits;
@@ -163,26 +180,36 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
     return this.runRead(principal, session, async (client) => {
       const seeds: SearchSeed[] = [];
       const resources = await client.query(
-        `SELECT r.resource_id,
-                ts_rank(to_tsvector('simple', r.title), plainto_tsquery('simple', $4)) AS rank
-         FROM kontext_resources r
-         WHERE r.organization_id = $1 AND r.status = 'active'
-           AND to_tsvector('simple', r.title) @@ plainto_tsquery('simple', $4)
-           AND ${aclPredicate("r")}
-         ORDER BY rank DESC
+        `WITH matches AS (
+           SELECT r.resource_id,
+                  ts_rank(to_tsvector('simple', r.title), plainto_tsquery('simple', $4)) AS native_rank
+           FROM kontext_resources r
+           WHERE r.organization_id = $1 AND r.status = 'active'
+             AND to_tsvector('simple', r.title) @@ plainto_tsquery('simple', $4)
+             AND ${aclPredicate("r")}
+         )
+         SELECT resource_id, native_rank,
+                row_number() OVER (ORDER BY native_rank DESC, resource_id) AS retrieval_rank,
+                count(*) OVER () AS candidate_count
+         FROM matches
+         ORDER BY native_rank DESC, resource_id
          LIMIT 10`,
         [principal.organizationId, principal.subjectId, [...principal.groupIds], question],
       );
       for (const row of resources.rows) {
         seeds.push({
           node: { kind: "resource", id: String(row.resource_id) },
-          score: Math.max(0.2, Math.min(1, Number(row.rank))),
+          observations: {
+            providers: ["postgres-resource-lexical"],
+            query: { lexical: rankedObservation(row) },
+          },
         });
       }
 
       const entities = await client.query(
-        `SELECT DISTINCT entity.entity_id,
-                ts_rank(to_tsvector('simple', entity.name), plainto_tsquery('simple', $4)) AS rank
+        `WITH matches AS (
+         SELECT entity.entity_id,
+                max(ts_rank(to_tsvector('simple', entity.name), plainto_tsquery('simple', $4))) AS native_rank
          FROM kontext_entities entity
          JOIN kontext_entity_mentions mention
            ON mention.organization_id = entity.organization_id AND mention.entity_id = entity.entity_id
@@ -194,36 +221,67 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
            AND mention.status = 'active' AND c.status = 'active' AND r.status = 'active'
            AND to_tsvector('simple', entity.name) @@ plainto_tsquery('simple', $4)
            AND ${aclPredicate("c")} AND ${aclPredicate("r")}
-         ORDER BY rank DESC
+         GROUP BY entity.entity_id
+         )
+         SELECT entity_id, native_rank,
+                row_number() OVER (ORDER BY native_rank DESC, entity_id) AS retrieval_rank,
+                count(*) OVER () AS candidate_count
+         FROM matches
+         ORDER BY native_rank DESC, entity_id
          LIMIT 10`,
         [principal.organizationId, principal.subjectId, [...principal.groupIds], question],
       );
       for (const row of entities.rows) {
         seeds.push({
           node: { kind: "entity", id: String(row.entity_id) },
-          score: Math.max(0.25, Math.min(1, Number(row.rank))),
+          observations: {
+            providers: ["postgres-entity-lexical"],
+            query: { lexical: rankedObservation(row) },
+          },
         });
       }
 
       const graph = await loadActiveOntologyGraph(client, principal.organizationId);
       const queryTerms = terms(question);
       const ontologyNodes = normalizeOntologyNodes(graph?.nodes ?? []);
-      let ontologyMatches = 0;
+      const ontologyCandidates: Array<{
+        readonly node: StoredOntologyNode;
+        readonly overlap: number;
+        readonly exactMatch: boolean;
+      }> = [];
       for (const node of ontologyNodes) {
-        const overlap = Array.from(terms(`${node.id} ${node.description ?? ""}`)).filter((term) =>
-          queryTerms.has(term),
-        ).length;
+        const nodeTerms = terms(`${node.id} ${node.description ?? ""}`);
+        const overlap = Array.from(nodeTerms).filter((term) => queryTerms.has(term)).length;
         // Only seed ontology nodes that actually overlap the query. Non-overlapping
         // nodes are still reachable via resource/entity "lift" edges, so seeding all
         // of them just floods the frontier and wastes the traversal budget.
         if (overlap === 0) continue;
-        ontologyMatches++;
-        seeds.push({
-          node: { kind: "ontology", id: node.id },
-          score: Math.min(0.9, 0.45 + overlap * 0.15),
+        ontologyCandidates.push({
+          node,
+          overlap,
+          exactMatch: question.trim().toLocaleLowerCase() === node.id.toLocaleLowerCase(),
         });
       }
-      if (seeds.length === 0 && ontologyMatches === 0) {
+      ontologyCandidates.sort(
+        (left, right) => right.overlap - left.overlap || left.node.id.localeCompare(right.node.id),
+      );
+      for (const [index, candidate] of ontologyCandidates.entries()) {
+        seeds.push({
+          node: { kind: "ontology", id: candidate.node.id },
+          observations: {
+            providers: ["ontology-lexical"],
+            query: {
+              exactMatch: candidate.exactMatch,
+              lexical: {
+                rank: index + 1,
+                candidateCount: ontologyCandidates.length,
+                normalizedScore: queryTerms.size === 0 ? 0 : candidate.overlap / queryTerms.size,
+              },
+            },
+          },
+        });
+      }
+      if (seeds.length === 0 && ontologyCandidates.length === 0) {
         // The default runtime has no vector provider. Keep a bounded, deterministic
         // low-score backstop so a query with no exact lexical match does not produce
         // an empty frontier, while avoiding the old all-node candidate flood.
@@ -235,7 +293,10 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
           })
           .slice(0, FALLBACK_ONTOLOGY_SEED_LIMIT);
         for (const node of fallbackNodes) {
-          seeds.push({ node: { kind: "ontology", id: node.id }, score: 0.08 });
+          seeds.push({
+            node: { kind: "ontology", id: node.id },
+            observations: { fallback: true, providers: ["ontology-fallback"] },
+          });
         }
       }
       return seeds;
@@ -245,7 +306,7 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
   private async ontologyNeighbors(
     client: PoolClient,
     node: SearchNode,
-    _question: string,
+    question: string,
     principal: Principal,
   ): Promise<SearchEdge[]> {
     const output: SearchEdge[] = [];
@@ -253,24 +314,55 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
     const ontologyNodes = normalizeOntologyNodes(graph?.nodes ?? []);
     for (const relation of graph?.edges ?? []) {
       if (relation.from === node.id) {
+        const target = ontologyNodes.find((candidate) => candidate.id === relation.to);
         output.push(
-          makeEdge(node, { kind: "ontology", id: relation.to }, "expand", relation.weight),
+          makeEdge(
+            node,
+            { kind: "ontology", id: relation.to },
+            "expand",
+            { kind: "declared", weight: relation.weight },
+            queryMatchObservation(question, `${relation.to} ${target?.description ?? ""}`),
+          ),
         );
       } else if (relation.to === node.id) {
+        const target = ontologyNodes.find((candidate) => candidate.id === relation.from);
         output.push(
-          makeEdge(node, { kind: "ontology", id: relation.from }, "expand", relation.weight),
+          makeEdge(
+            node,
+            { kind: "ontology", id: relation.from },
+            "expand",
+            { kind: "declared", weight: relation.weight },
+            queryMatchObservation(question, `${relation.from} ${target?.description ?? ""}`),
+          ),
         );
       }
     }
     const current = ontologyNodes.find((candidate) => candidate.id === node.id);
     if (current?.parentId) {
-      output.push(makeEdge(node, { kind: "ontology", id: current.parentId }, "lift", 0.9));
+      const parent = ontologyNodes.find((candidate) => candidate.id === current.parentId);
+      output.push(
+        makeEdge(
+          node,
+          { kind: "ontology", id: current.parentId },
+          "lift",
+          { kind: "declared" },
+          queryMatchObservation(question, `${current.parentId} ${parent?.description ?? ""}`),
+        ),
+      );
     }
     for (const child of ontologyNodes.filter((candidate) => candidate.parentId === node.id)) {
-      output.push(makeEdge(node, { kind: "ontology", id: child.id }, "ground", 0.9));
+      output.push(
+        makeEdge(
+          node,
+          { kind: "ontology", id: child.id },
+          "ground",
+          { kind: "declared" },
+          queryMatchObservation(question, `${child.id} ${child.description ?? ""}`),
+        ),
+      );
     }
     const resources = await client.query(
-      `SELECT r.resource_id
+      `SELECT r.resource_id, r.title, link.origin, link.confidence
        FROM kontext_resource_ontology_links link
        JOIN kontext_resources r
          ON r.organization_id = link.organization_id AND r.resource_id = link.resource_id
@@ -280,7 +372,15 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
       [principal.organizationId, principal.subjectId, [...principal.groupIds], node.id],
     );
     for (const row of resources.rows) {
-      output.push(makeEdge(node, { kind: "resource", id: String(row.resource_id) }, "ground", 0.9));
+      output.push(
+        makeEdge(
+          node,
+          { kind: "resource", id: String(row.resource_id) },
+          "ground",
+          ontologyLinkObservation(row),
+          queryMatchObservation(question, String(row.title)),
+        ),
+      );
     }
     return output;
   }
@@ -288,23 +388,29 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
   private async resourceNeighbors(
     client: PoolClient,
     node: SearchNode,
-    _question: string,
+    question: string,
     principal: Principal,
   ): Promise<SearchEdge[]> {
     if (!(await visibleResource(client, node.id, principal))) return [];
     const output: SearchEdge[] = [];
     const links = await client.query(
-      `SELECT ontology_node_id FROM kontext_resource_ontology_links
+      `SELECT ontology_node_id, origin, confidence FROM kontext_resource_ontology_links
        WHERE organization_id = $1 AND resource_id = $2`,
       [principal.organizationId, node.id],
     );
     for (const row of links.rows) {
       output.push(
-        makeEdge(node, { kind: "ontology", id: String(row.ontology_node_id) }, "lift", 0.9),
+        makeEdge(
+          node,
+          { kind: "ontology", id: String(row.ontology_node_id) },
+          "lift",
+          ontologyLinkObservation(row),
+          queryMatchObservation(question, String(row.ontology_node_id)),
+        ),
       );
     }
     const chunks = await client.query(
-      `SELECT c.chunk_id
+      `SELECT c.chunk_id, count(*) OVER () AS candidate_count
        FROM kontext_chunks c
        WHERE c.organization_id = $1 AND c.resource_id = $4 AND c.status = 'active'
          AND ${aclPredicate("c")}
@@ -313,7 +419,21 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
       [principal.organizationId, principal.subjectId, [...principal.groupIds], node.id],
     );
     for (const row of chunks.rows) {
-      output.push(makeEdge(node, { kind: "chunk", id: String(row.chunk_id) }, "ground", 0.95));
+      output.push(
+        makeEdge(
+          node,
+          { kind: "chunk", id: String(row.chunk_id) },
+          "ground",
+          { kind: "deterministic" },
+          undefined,
+          undefined,
+          {
+            returnedCount: chunks.rows.length,
+            candidateCount: finitePositiveInteger(row.candidate_count),
+          },
+          { supportApplicability: "not-applicable" },
+        ),
+      );
     }
     return output;
   }
@@ -321,7 +441,7 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
   private async chunkNeighbors(
     client: PoolClient,
     node: SearchNode,
-    _question: string,
+    question: string,
     principal: Principal,
   ): Promise<SearchEdge[]> {
     const chunk = await client.query(
@@ -336,23 +456,61 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
     );
     const resourceId = chunk.rows[0]?.resource_id;
     if (!resourceId) return [];
-    const output = [makeEdge(node, { kind: "resource", id: String(resourceId) }, "lift", 0.95)];
+    const output = [
+      makeEdge(
+        node,
+        { kind: "resource", id: String(resourceId) },
+        "lift",
+        { kind: "deterministic" },
+        undefined,
+        undefined,
+        undefined,
+        { queryApplicability: "not-applicable", supportApplicability: "not-applicable" },
+      ),
+    ];
     const entities = await client.query(
-      `SELECT entity_id FROM kontext_entity_mentions
-       WHERE organization_id = $1 AND chunk_id = $2 AND status = 'active'`,
+      `SELECT mention.entity_id, mention.extraction_confidence, mention.extractor_version,
+              mention.origin,
+              entity.name
+       FROM kontext_entity_mentions mention
+       JOIN kontext_entities entity
+         ON entity.organization_id = mention.organization_id AND entity.entity_id = mention.entity_id
+       WHERE mention.organization_id = $1 AND mention.chunk_id = $2
+         AND mention.status = 'active' AND entity.status = 'active'`,
       [principal.organizationId, node.id],
     );
     for (const row of entities.rows) {
-      output.push(makeEdge(node, { kind: "entity", id: String(row.entity_id) }, "lift", 0.9));
+      output.push(
+        makeEdge(
+          node,
+          { kind: "entity", id: String(row.entity_id) },
+          "lift",
+          extractedObservation(row.extraction_confidence, row.extractor_version, row.origin),
+          queryMatchObservation(question, String(row.name)),
+        ),
+      );
     }
     const facts = await client.query(
-      `SELECT fact_key FROM kontext_evidence
-       WHERE organization_id = $1 AND chunk_id = $2 AND status = 'active'
-         AND fact_key IS NOT NULL`,
+      `SELECT evidence.fact_key, fact.predicate, fact.subject, fact.object,
+              fact.extraction_confidence, fact.extractor_version, fact.origin
+       FROM kontext_evidence evidence
+       JOIN kontext_facts fact
+         ON fact.organization_id = evidence.organization_id AND fact.fact_key = evidence.fact_key
+       WHERE evidence.organization_id = $1 AND evidence.chunk_id = $2
+         AND evidence.status = 'active' AND evidence.fact_key IS NOT NULL
+         AND fact.status IN ('active', 'conflict')`,
       [principal.organizationId, node.id],
     );
     for (const row of facts.rows) {
-      output.push(makeEdge(node, { kind: "fact", id: String(row.fact_key) }, "lift", 0.95));
+      output.push(
+        makeEdge(
+          node,
+          { kind: "fact", id: String(row.fact_key) },
+          "lift",
+          extractedObservation(row.extraction_confidence, row.extractor_version, row.origin),
+          queryMatchObservation(question, factSearchText(row)),
+        ),
+      );
     }
     return output;
   }
@@ -360,12 +518,13 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
   private async entityNeighbors(
     client: PoolClient,
     node: SearchNode,
-    _question: string,
+    question: string,
     principal: Principal,
   ): Promise<SearchEdge[]> {
     const output: SearchEdge[] = [];
     const chunks = await client.query(
-      `SELECT mention.chunk_id
+      `SELECT mention.chunk_id, mention.extraction_confidence, mention.extractor_version,
+              mention.origin, count(*) OVER () AS candidate_count
        FROM kontext_entity_mentions mention
        JOIN kontext_chunks c
          ON c.organization_id = mention.organization_id AND c.chunk_id = mention.chunk_id
@@ -378,10 +537,30 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
       [principal.organizationId, principal.subjectId, [...principal.groupIds], node.id],
     );
     for (const row of chunks.rows) {
-      output.push(makeEdge(node, { kind: "chunk", id: String(row.chunk_id) }, "ground", 0.85));
+      output.push(
+        makeEdge(
+          node,
+          { kind: "chunk", id: String(row.chunk_id) },
+          "ground",
+          extractedObservation(row.extraction_confidence, row.extractor_version, row.origin),
+          undefined,
+          undefined,
+          {
+            returnedCount: chunks.rows.length,
+            candidateCount: finitePositiveInteger(row.candidate_count),
+          },
+          { supportApplicability: "not-applicable" },
+        ),
+      );
     }
     const facts = await client.query(
-      `SELECT DISTINCT f.fact_key
+      `SELECT f.fact_key, f.predicate, f.subject, f.object,
+              f.extraction_confidence, f.extractor_version, f.origin,
+              count(DISTINCT e.evidence_id) AS active_evidence_count,
+              count(DISTINCT e.resource_id) AS distinct_resource_count,
+              count(DISTINCT e.evidence_id) FILTER (WHERE e.origin = 'curated') AS curated_evidence_count,
+              count(DISTINCT e.evidence_id) FILTER (WHERE e.origin = 'derived') AS derived_evidence_count,
+              count(DISTINCT e.evidence_id) FILTER (WHERE f.status = 'conflict') AS conflict_count
        FROM kontext_facts f
        JOIN kontext_evidence e
          ON e.organization_id = f.organization_id AND e.fact_key = f.fact_key
@@ -396,11 +575,22 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
            (f.object->>'kind' = 'entity' AND f.object->'entity'->>'entityId' = $4)
          )
          AND ${aclPredicate("e")} AND ${aclPredicate("c")} AND ${aclPredicate("r")}
+       GROUP BY f.fact_key, f.predicate, f.subject, f.object,
+                f.extraction_confidence, f.extractor_version, f.origin
        LIMIT 30`,
       [principal.organizationId, principal.subjectId, [...principal.groupIds], node.id],
     );
     for (const row of facts.rows) {
-      output.push(makeEdge(node, { kind: "fact", id: String(row.fact_key) }, "expand", 0.9));
+      output.push(
+        makeEdge(
+          node,
+          { kind: "fact", id: String(row.fact_key) },
+          "expand",
+          extractedObservation(row.extraction_confidence, row.extractor_version, row.origin),
+          queryMatchObservation(question, factSearchText(row)),
+          supportObservation(row),
+        ),
+      );
     }
     return output;
   }
@@ -408,11 +598,13 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
   private async factNeighbors(
     client: PoolClient,
     node: SearchNode,
-    _question: string,
+    question: string,
     principal: Principal,
   ): Promise<SearchEdge[]> {
     const result = await client.query(
-      `SELECT f.subject, f.object, e.chunk_id
+      `SELECT f.subject, f.predicate, f.object, f.status,
+              f.extraction_confidence, f.extractor_version, f.origin AS fact_origin,
+              e.chunk_id, e.resource_id, e.origin AS evidence_origin, e.confidence
        FROM kontext_facts f
        JOIN kontext_evidence e
          ON e.organization_id = f.organization_id AND e.fact_key = f.fact_key
@@ -427,11 +619,28 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
       [principal.organizationId, principal.subjectId, [...principal.groupIds], node.id],
     );
     const output: SearchEdge[] = [];
+    const support = supportFromEvidenceRows(result.rows);
     for (const row of result.rows) {
-      output.push(makeEdge(node, { kind: "chunk", id: String(row.chunk_id) }, "ground", 1));
+      output.push(
+        makeEdge(
+          node,
+          { kind: "chunk", id: String(row.chunk_id) },
+          "ground",
+          extractedObservation(row.confidence, row.extractor_version, row.evidence_origin),
+          undefined,
+          support,
+        ),
+      );
       if (row.subject?.entityId) {
         output.push(
-          makeEdge(node, { kind: "entity", id: String(row.subject.entityId) }, "expand", 0.95),
+          makeEdge(
+            node,
+            { kind: "entity", id: String(row.subject.entityId) },
+            "expand",
+            extractedObservation(row.extraction_confidence, row.extractor_version, row.fact_origin),
+            queryMatchObservation(question, factSearchText(row)),
+            support,
+          ),
         );
       }
       if (row.object?.kind === "entity" && row.object.entity?.entityId) {
@@ -440,7 +649,9 @@ export class PostgresKnowledgeSearchGraph implements SearchGraphPort {
             node,
             { kind: "entity", id: String(row.object.entity.entityId) },
             "expand",
-            0.95,
+            extractedObservation(row.extraction_confidence, row.extractor_version, row.fact_origin),
+            queryMatchObservation(question, factSearchText(row)),
+            support,
           ),
         );
       }
@@ -483,9 +694,37 @@ function makeEdge(
   from: SearchNode,
   to: SearchNode,
   operation: SearchEdge["operation"],
-  confidence = 1,
+  structural: SearchEdgeObservations["structural"],
+  query?: SearchEdgeObservations["query"],
+  support?: SearchEdgeObservations["support"],
+  fanout?: SearchEdgeObservations["fanout"],
+  applicability?: Pick<SearchEdgeObservations, "queryApplicability" | "supportApplicability">,
 ): SearchEdge {
-  return { from, to, operation, confidence, queryRelevance: 0.8, evidenceSupport: 0.8 };
+  return {
+    from,
+    to,
+    operation,
+    observations: {
+      ...(structural === undefined ? {} : { structural }),
+      ...(query === undefined ? {} : { query }),
+      ...(support === undefined ? {} : { support }),
+      ...(fanout === undefined ? {} : { fanout }),
+      ...applicability,
+    },
+  };
+}
+
+function ontologyLinkObservation(
+  row: QueryResultRow,
+): SearchEdgeObservations["structural"] | undefined {
+  if (row.origin === "deterministic") return { kind: "deterministic" };
+  if (row.origin === "manual") {
+    return { kind: "declared", weight: optionalScore(row.confidence) };
+  }
+  if (row.origin === "automatic") {
+    return { kind: "inferred", confidence: optionalScore(row.confidence) };
+  }
+  return undefined;
 }
 
 function normalizeOntologyNodes(
@@ -512,7 +751,109 @@ function deduplicateEdges(edges: readonly SearchEdge[]): SearchEdge[] {
   for (const edge of edges) {
     const key = `${edge.operation}:${nodeKey(edge.to)}`;
     const previous = best.get(key);
-    if (!previous || edge.confidence > previous.confidence) best.set(key, edge);
+    if (!previous || edgeOrderingScore(edge) > edgeOrderingScore(previous)) best.set(key, edge);
   }
   return Array.from(best.values());
+}
+
+function rankedObservation(row: QueryResultRow): {
+  readonly rank: number;
+  readonly candidateCount: number;
+} {
+  return {
+    rank: finitePositiveInteger(row.retrieval_rank),
+    candidateCount: finitePositiveInteger(row.candidate_count),
+  };
+}
+
+function queryMatchObservation(
+  question: string,
+  searchableText: string,
+): SearchEdgeObservations["query"] | undefined {
+  const questionTerms = terms(question);
+  const candidateTerms = terms(searchableText);
+  if (questionTerms.size === 0 || candidateTerms.size === 0) return undefined;
+  const overlap = Array.from(questionTerms).filter((term) => candidateTerms.has(term)).length;
+  if (overlap === 0) return undefined;
+  return {
+    exactMatch: question.trim().toLocaleLowerCase() === searchableText.trim().toLocaleLowerCase(),
+    lexical: {
+      rank: 1,
+      candidateCount: 1,
+      normalizedScore: overlap / questionTerms.size,
+    },
+  };
+}
+
+function extractedObservation(
+  confidence: unknown,
+  extractorVersion: unknown,
+  origin?: unknown,
+): NonNullable<SearchEdgeObservations["structural"]> {
+  if (origin === "curated") return { kind: "declared", weight: optionalScore(confidence) };
+  return {
+    kind: "extracted",
+    ...(confidence === null || confidence === undefined ? {} : { confidence: Number(confidence) }),
+    ...(extractorVersion === null || extractorVersion === undefined
+      ? {}
+      : { extractorVersion: String(extractorVersion) }),
+  };
+}
+
+function optionalScore(value: unknown): number | undefined {
+  if (value === null || value === undefined) return undefined;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? Math.max(0, Math.min(1, numeric)) : undefined;
+}
+
+function supportObservation(row: QueryResultRow): SearchEdgeObservations["support"] {
+  return {
+    activeEvidenceCount: Number(row.active_evidence_count ?? 0),
+    curatedEvidenceCount: Number(row.curated_evidence_count ?? 0),
+    derivedEvidenceCount: Number(row.derived_evidence_count ?? 0),
+    distinctResourceCount: Number(row.distinct_resource_count ?? 0),
+    conflictCount: Number(row.conflict_count ?? 0),
+    staleEvidenceCount: Number(row.stale_evidence_count ?? 0),
+  };
+}
+
+function supportFromEvidenceRows(
+  rows: readonly QueryResultRow[],
+): SearchEdgeObservations["support"] {
+  const resources = new Set(rows.map((row) => String(row.resource_id)));
+  return {
+    activeEvidenceCount: rows.length,
+    curatedEvidenceCount: rows.filter((row) => row.evidence_origin === "curated").length,
+    derivedEvidenceCount: rows.filter((row) => row.evidence_origin === "derived").length,
+    distinctResourceCount: resources.size,
+    conflictCount: rows.some((row) => row.status === "conflict") ? rows.length : 0,
+    staleEvidenceCount: 0,
+  };
+}
+
+function factSearchText(row: QueryResultRow): string {
+  return `${String(row.fact_key ?? "")} ${String(row.predicate ?? "")} ${JSON.stringify(
+    row.subject ?? {},
+  )} ${JSON.stringify(row.object ?? {})}`;
+}
+
+function edgeOrderingScore(edge: SearchEdge): number {
+  const structural = edge.observations?.structural;
+  if (structural?.kind === "deterministic") return 4;
+  if (structural?.kind === "declared") return 3 + (structural.weight ?? 0);
+  if (structural?.kind === "extracted" || structural?.kind === "inferred") {
+    return (structural.kind === "extracted" ? 2 : 1) + (structural.confidence ?? 0);
+  }
+  return edge.confidence ?? 0;
+}
+
+function ageInDays(value: unknown): number | undefined {
+  const timestamp = new Date(String(value)).getTime();
+  if (!Number.isFinite(timestamp)) return undefined;
+  return Math.max(0, (Date.now() - timestamp) / 86_400_000);
+}
+
+function finitePositiveInteger(value: unknown): number {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? Math.max(1, Math.floor(numeric)) : 1;
 }

--- a/packages/postgres/src/postgres-runtime.ts
+++ b/packages/postgres/src/postgres-runtime.ts
@@ -1,6 +1,8 @@
 import {
   ActivateOntologyUseCase,
   BidirectionalNLayerRetriever,
+  CalibratedTraversalScorePolicy,
+  DEFAULT_CALIBRATED_SCORING_PROFILE,
   type OntologyReindexer,
   type ResourceContentStore,
   type ResourceSnapshotEnricher,
@@ -17,6 +19,7 @@ import { PostgresKnowledgeSearchGraph } from "./postgres-knowledge-search-graph.
 import type { StoredOntologyGraph } from "./postgres-knowledge-search-graph.js";
 import { PostgresOntologyDeploymentRepository } from "./postgres-ontology-deployments.js";
 import { PostgresOntologyProposalQueue } from "./postgres-ontology-proposal-queue.js";
+import { PostgresScoringProfileRepository } from "./postgres-scoring-profiles.js";
 
 export function createPostgresKnowledgeRuntime(
   pool: Pool,
@@ -30,12 +33,19 @@ export function createPostgresKnowledgeRuntime(
   const searchGraph = new PostgresKnowledgeSearchGraph(pool, contentStore);
   const ontologyProposalQueue = new PostgresOntologyProposalQueue(pool);
   const ontologyDeployments = new PostgresOntologyDeploymentRepository<StoredOntologyGraph>(pool);
+  const scoringProfiles = new PostgresScoringProfileRepository(
+    pool,
+    5_000,
+    () => new CalibratedTraversalScorePolicy(DEFAULT_CALIBRATED_SCORING_PROFILE),
+  );
   return {
     repository,
     authorizedReader: new PostgresAuthorizedKnowledgeGraphReader(pool),
     resourceSync,
     searchGraph,
-    knowledgeRetriever: new BidirectionalNLayerRetriever(searchGraph),
+    // With no active profile the resolver preserves legacy-v1. Activating a
+    // staged profile switches future requests by organization without restart.
+    knowledgeRetriever: new BidirectionalNLayerRetriever(searchGraph, scoringProfiles),
     mcpKnowledgeSynchronizer: new MCPKnowledgeSynchronizer(
       resourceSync,
       mcpAdapters,
@@ -43,6 +53,7 @@ export function createPostgresKnowledgeRuntime(
     ),
     ontologyProposalQueue,
     ontologyDeployments,
+    scoringProfiles,
     ontologyActivation: {
       async activate(input: {
         organizationId: string;

--- a/packages/postgres/src/postgres-scoring-profiles.ts
+++ b/packages/postgres/src/postgres-scoring-profiles.ts
@@ -1,0 +1,414 @@
+import {
+  type AnyTraversalScorePolicy,
+  BalancedTraversalScorePolicy,
+  CalibratedTraversalScorePolicy,
+  type Principal,
+  type TraversalScorePolicyResolver,
+  type TraversalScoringProfile,
+  scoringProfileDigest,
+  validateTraversalScoringProfile,
+} from "@kontext-brain/core";
+import type { Pool, QueryResultRow } from "pg";
+import { withOrganizationTransaction } from "./postgres-knowledge-graph.js";
+import { toIsoString } from "./postgres-value-utils.js";
+
+export type ScoringProfileDeploymentStatus = "staged" | "active" | "retired" | "failed";
+
+export interface ScoringProfileDeployment {
+  readonly organizationId: string;
+  readonly profile: TraversalScoringProfile;
+  readonly profileDigest: string;
+  readonly status: ScoringProfileDeploymentStatus;
+  readonly failure?: string;
+  readonly createdAt: string;
+  readonly evaluationSummary?: Readonly<Record<string, unknown>>;
+}
+
+export interface ScoringProfileActivationOptions {
+  /** Break-glass only; normal activation requires a persisted evaluation summary. */
+  readonly allowUnevaluated?: boolean;
+}
+
+/**
+ * Stores immutable scoring profiles and resolves one profile per retrieval.
+ * The short cache avoids a profile lookup on every question; activation clears
+ * this process's entry immediately and other processes converge after the TTL.
+ */
+export class PostgresScoringProfileRepository implements TraversalScorePolicyResolver {
+  private readonly activeCache = new Map<
+    string,
+    {
+      readonly expiresAt: number;
+      readonly policy: AnyTraversalScorePolicy | null;
+      readonly canaryPercent: number;
+    }
+  >();
+  private readonly shadowCache = new Map<
+    string,
+    { readonly expiresAt: number; readonly policy: AnyTraversalScorePolicy | null }
+  >();
+
+  constructor(
+    private readonly pool: Pool,
+    private readonly cacheTtlMs = 5_000,
+    private readonly fallbackPolicy: () => AnyTraversalScorePolicy = () =>
+      new BalancedTraversalScorePolicy(),
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  async resolve(principal: Principal): Promise<AnyTraversalScorePolicy> {
+    const cached = this.activeCache.get(principal.organizationId);
+    const selection =
+      cached && cached.expiresAt > this.now()
+        ? cached
+        : await this.loadActiveSelection(principal.organizationId);
+    if (selection.policy && inDeterministicCanary(principal, selection.canaryPercent)) {
+      return selection.policy;
+    }
+    return this.fallbackPolicy();
+  }
+
+  async setCanaryPercent(organizationId: string, percent: number): Promise<void> {
+    if (!Number.isInteger(percent) || percent < 0 || percent > 100) {
+      throw new Error("Scoring canary percent must be an integer between 0 and 100");
+    }
+    await withOrganizationTransaction(this.pool, organizationId, async (client) => {
+      await client.query(
+        `INSERT INTO kontext_organization_runtime (organization_id, scoring_canary_percent)
+         VALUES ($1,$2)
+         ON CONFLICT (organization_id) DO UPDATE SET
+           scoring_canary_percent = EXCLUDED.scoring_canary_percent`,
+        [organizationId, percent],
+      );
+    });
+    this.activeCache.delete(organizationId);
+  }
+
+  async resolveShadow(principal: Principal): Promise<AnyTraversalScorePolicy | null> {
+    const cached = this.shadowCache.get(principal.organizationId);
+    if (cached && cached.expiresAt > this.now()) return cached.policy;
+    const shadow = await this.getShadow(principal.organizationId);
+    const policy = shadow ? new CalibratedTraversalScorePolicy(shadow.profile) : null;
+    this.shadowCache.set(principal.organizationId, {
+      expiresAt: this.now() + this.cacheTtlMs,
+      policy,
+    });
+    return policy;
+  }
+
+  async getActive(organizationId: string): Promise<ScoringProfileDeployment | null> {
+    return withOrganizationTransaction(
+      this.pool,
+      organizationId,
+      async (client) => {
+        const result = await client.query(
+          `SELECT profile.*
+           FROM kontext_organization_runtime runtime
+           JOIN kontext_scoring_profiles profile
+             ON profile.organization_id = runtime.organization_id
+            AND profile.profile_digest = runtime.active_scoring_profile_digest
+           WHERE runtime.organization_id = $1`,
+          [organizationId],
+        );
+        return result.rows[0] ? mapDeployment(result.rows[0]) : null;
+      },
+      { readOnly: true },
+    );
+  }
+
+  private async loadActiveSelection(organizationId: string): Promise<{
+    readonly expiresAt: number;
+    readonly policy: AnyTraversalScorePolicy | null;
+    readonly canaryPercent: number;
+  }> {
+    const selection = await withOrganizationTransaction(
+      this.pool,
+      organizationId,
+      async (client) => {
+        const result = await client.query(
+          `SELECT profile.*, runtime.scoring_canary_percent
+           FROM kontext_organization_runtime runtime
+           LEFT JOIN kontext_scoring_profiles profile
+             ON profile.organization_id = runtime.organization_id
+            AND profile.profile_digest = runtime.active_scoring_profile_digest
+           WHERE runtime.organization_id = $1`,
+          [organizationId],
+        );
+        const row = result.rows[0];
+        return {
+          policy:
+            row?.profile_digest == null
+              ? null
+              : new CalibratedTraversalScorePolicy(mapDeployment(row).profile),
+          canaryPercent:
+            row?.scoring_canary_percent == null ? 100 : Number(row.scoring_canary_percent),
+        };
+      },
+      { readOnly: true },
+    );
+    const cached = {
+      ...selection,
+      expiresAt: this.now() + this.cacheTtlMs,
+    };
+    this.activeCache.set(organizationId, cached);
+    return cached;
+  }
+
+  async getShadow(organizationId: string): Promise<ScoringProfileDeployment | null> {
+    return withOrganizationTransaction(
+      this.pool,
+      organizationId,
+      async (client) => {
+        const result = await client.query(
+          `SELECT profile.*
+           FROM kontext_organization_runtime runtime
+           JOIN kontext_scoring_profiles profile
+             ON profile.organization_id = runtime.organization_id
+            AND profile.profile_digest = runtime.shadow_scoring_profile_digest
+           WHERE runtime.organization_id = $1`,
+          [organizationId],
+        );
+        return result.rows[0] ? mapDeployment(result.rows[0]) : null;
+      },
+      { readOnly: true },
+    );
+  }
+
+  async stage(
+    organizationId: string,
+    profile: TraversalScoringProfile,
+    evaluationSummary?: Readonly<Record<string, unknown>>,
+  ): Promise<ScoringProfileDeployment> {
+    validateTraversalScoringProfile(profile);
+    const profileDigest = scoringProfileDigest(profile);
+    const createdAt = new Date().toISOString();
+    const deployment = await withOrganizationTransaction(
+      this.pool,
+      organizationId,
+      async (client) => {
+        const result = await client.query(
+          `INSERT INTO kontext_scoring_profiles (
+             organization_id, profile_id, version, feature_schema_version, profile_digest, profile_data,
+             evaluation_summary, status, created_at
+           ) VALUES ($1,$2,$3,$4,$5,$6::jsonb,$7::jsonb,'staged',$8)
+           ON CONFLICT (organization_id, profile_digest) DO UPDATE SET
+             profile_data = EXCLUDED.profile_data,
+             evaluation_summary = EXCLUDED.evaluation_summary,
+             status = CASE
+               WHEN kontext_scoring_profiles.status = 'active' THEN 'active'
+               ELSE 'staged'
+             END,
+             failure = NULL
+           RETURNING *`,
+          [
+            organizationId,
+            profile.id,
+            profile.version,
+            profile.featureSchemaVersion,
+            profileDigest,
+            JSON.stringify(profile),
+            evaluationSummary === undefined ? null : JSON.stringify(evaluationSummary),
+            createdAt,
+          ],
+        );
+        const row = result.rows[0];
+        if (!row) throw new Error(`Scoring profile "${profile.id}" was not staged`);
+        return mapDeployment(row);
+      },
+    );
+    return deployment;
+  }
+
+  async activate(
+    organizationId: string,
+    profileDigest: string,
+    options: ScoringProfileActivationOptions = {},
+  ): Promise<ScoringProfileDeployment> {
+    const deployment = await withOrganizationTransaction(
+      this.pool,
+      organizationId,
+      async (client) => {
+        const locked = await client.query(
+          `SELECT status, evaluation_summary
+           FROM kontext_scoring_profiles
+           WHERE organization_id = $1 AND profile_digest = $2
+           FOR UPDATE`,
+          [organizationId, profileDigest],
+        );
+        if (locked.rows[0]?.status !== "staged") {
+          throw new Error(`Scoring profile "${profileDigest}" is not staged`);
+        }
+        if (locked.rows[0]?.evaluation_summary == null && !options.allowUnevaluated) {
+          throw new Error(`Scoring profile "${profileDigest}" has no evaluation summary`);
+        }
+        await client.query(
+          `UPDATE kontext_scoring_profiles
+           SET status = 'retired'
+           WHERE organization_id = $1 AND status = 'active' AND profile_digest <> $2`,
+          [organizationId, profileDigest],
+        );
+        const activated = await client.query(
+          `UPDATE kontext_scoring_profiles
+           SET status = 'active', failure = NULL
+           WHERE organization_id = $1 AND profile_digest = $2
+           RETURNING *`,
+          [organizationId, profileDigest],
+        );
+        await client.query(
+          `INSERT INTO kontext_organization_runtime (
+             organization_id, active_scoring_profile_digest
+           ) VALUES ($1,$2)
+           ON CONFLICT (organization_id) DO UPDATE SET
+             active_scoring_profile_digest = EXCLUDED.active_scoring_profile_digest`,
+          [organizationId, profileDigest],
+        );
+        await client.query(
+          `UPDATE kontext_organization_runtime
+           SET shadow_scoring_profile_digest = NULL
+           WHERE organization_id = $1 AND shadow_scoring_profile_digest = $2`,
+          [organizationId, profileDigest],
+        );
+        const row = activated.rows[0];
+        if (!row) throw new Error(`Scoring profile "${profileDigest}" was not activated`);
+        return mapDeployment(row);
+      },
+    );
+    this.activeCache.delete(organizationId);
+    this.shadowCache.delete(organizationId);
+    return deployment;
+  }
+
+  async rollback(organizationId: string, profileDigest: string): Promise<ScoringProfileDeployment> {
+    const deployment = await withOrganizationTransaction(
+      this.pool,
+      organizationId,
+      async (client) => {
+        const target = await client.query(
+          `SELECT status FROM kontext_scoring_profiles
+           WHERE organization_id = $1 AND profile_digest = $2
+           FOR UPDATE`,
+          [organizationId, profileDigest],
+        );
+        if (!target.rows[0] || target.rows[0].status === "failed") {
+          throw new Error(`Scoring profile "${profileDigest}" is not available for rollback`);
+        }
+        await client.query(
+          `UPDATE kontext_scoring_profiles
+           SET status = 'retired'
+           WHERE organization_id = $1 AND status = 'active' AND profile_digest <> $2`,
+          [organizationId, profileDigest],
+        );
+        const restored = await client.query(
+          `UPDATE kontext_scoring_profiles
+           SET status = 'active', failure = NULL
+           WHERE organization_id = $1 AND profile_digest = $2
+           RETURNING *`,
+          [organizationId, profileDigest],
+        );
+        await client.query(
+          `INSERT INTO kontext_organization_runtime (
+             organization_id, active_scoring_profile_digest, scoring_canary_percent
+           ) VALUES ($1,$2,100)
+           ON CONFLICT (organization_id) DO UPDATE SET
+             active_scoring_profile_digest = EXCLUDED.active_scoring_profile_digest,
+             scoring_canary_percent = 100`,
+          [organizationId, profileDigest],
+        );
+        await client.query(
+          `UPDATE kontext_organization_runtime
+           SET shadow_scoring_profile_digest = NULL
+           WHERE organization_id = $1 AND shadow_scoring_profile_digest = $2`,
+          [organizationId, profileDigest],
+        );
+        const row = restored.rows[0];
+        if (!row) throw new Error(`Scoring profile "${profileDigest}" was not restored`);
+        return mapDeployment(row);
+      },
+    );
+    this.activeCache.delete(organizationId);
+    this.shadowCache.delete(organizationId);
+    return deployment;
+  }
+
+  async setShadow(organizationId: string, profileDigest: string | null): Promise<void> {
+    await withOrganizationTransaction(this.pool, organizationId, async (client) => {
+      if (profileDigest !== null) {
+        const profile = await client.query(
+          `SELECT 1 FROM kontext_scoring_profiles
+           WHERE organization_id = $1 AND profile_digest = $2 AND status <> 'failed'`,
+          [organizationId, profileDigest],
+        );
+        if (profile.rowCount !== 1) {
+          throw new Error(`Scoring profile "${profileDigest}" is not available for shadowing`);
+        }
+        const active = await client.query(
+          `SELECT 1 FROM kontext_organization_runtime
+           WHERE organization_id = $1 AND active_scoring_profile_digest = $2`,
+          [organizationId, profileDigest],
+        );
+        if (active.rowCount === 1) {
+          throw new Error("Shadow scoring profile must differ from the active profile");
+        }
+      }
+      await client.query(
+        `INSERT INTO kontext_organization_runtime (
+           organization_id, shadow_scoring_profile_digest
+         ) VALUES ($1,$2)
+         ON CONFLICT (organization_id) DO UPDATE SET
+           shadow_scoring_profile_digest = EXCLUDED.shadow_scoring_profile_digest`,
+        [organizationId, profileDigest],
+      );
+    });
+    this.shadowCache.delete(organizationId);
+  }
+
+  async markFailed(organizationId: string, profileDigest: string, failure: string): Promise<void> {
+    await withOrganizationTransaction(this.pool, organizationId, async (client) => {
+      await client.query(
+        `UPDATE kontext_scoring_profiles
+         SET status = 'failed', failure = $3
+         WHERE organization_id = $1 AND profile_digest = $2 AND status <> 'active'`,
+        [organizationId, profileDigest, failure],
+      );
+    });
+  }
+}
+
+function mapDeployment(row: QueryResultRow): ScoringProfileDeployment {
+  const profile = row.profile_data as TraversalScoringProfile;
+  validateTraversalScoringProfile(profile);
+  const expectedDigest = scoringProfileDigest(profile);
+  const storedDigest = String(row.profile_digest);
+  if (String(row.feature_schema_version) !== profile.featureSchemaVersion) {
+    throw new Error("Scoring profile feature schema column does not match profile data");
+  }
+  if (storedDigest !== expectedDigest) {
+    throw new Error(
+      `Scoring profile digest mismatch: stored ${storedDigest}, computed ${expectedDigest}`,
+    );
+  }
+  return {
+    organizationId: String(row.organization_id),
+    profile,
+    profileDigest: storedDigest,
+    status: row.status as ScoringProfileDeploymentStatus,
+    failure: row.failure === null ? undefined : String(row.failure),
+    createdAt: toIsoString(row.created_at),
+    evaluationSummary:
+      row.evaluation_summary === null || row.evaluation_summary === undefined
+        ? undefined
+        : (row.evaluation_summary as Readonly<Record<string, unknown>>),
+  };
+}
+
+function inDeterministicCanary(principal: Principal, percent: number): boolean {
+  if (percent <= 0) return false;
+  if (percent >= 100) return true;
+  const value = `${principal.organizationId}:${principal.subjectId}`;
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash % 100 < percent;
+}

--- a/packages/postgres/tests/postgres-adapters.test.ts
+++ b/packages/postgres/tests/postgres-adapters.test.ts
@@ -1,6 +1,8 @@
 import {
   ActivateOntologyUseCase,
   BidirectionalNLayerRetriever,
+  CalibratedTraversalScorePolicy,
+  DEFAULT_CALIBRATED_SCORING_PROFILE,
   InMemoryResourceContentStore,
   type OntologyCandidateValidator,
   type OntologyCompiler,
@@ -19,6 +21,7 @@ import {
   PostgresKnowledgeSearchGraph,
   PostgresOntologyDeploymentRepository,
   PostgresOntologyProposalQueue,
+  PostgresScoringProfileRepository,
   migratePostgres,
 } from "../src/index.js";
 
@@ -89,6 +92,65 @@ describe.runIf(pool !== null)("PostgreSQL adapters", () => {
     await expect(activate.execute({ organizationId: "acme", yaml: "invalid" })).rejects.toThrow();
 
     expect(await repository.getActive("acme")).toEqual(active);
+  });
+
+  it("stages and atomically activates versioned scoring profiles", async () => {
+    const profiles = new PostgresScoringProfileRepository(requiredPool(), 0);
+    const profile = {
+      ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+      id: "test-calibrated",
+      version: 2,
+    };
+
+    const staged = await profiles.stage("acme", profile, {
+      split: "validation",
+      recallAt10: 1,
+      ndcgAt10: 1,
+    });
+    expect(staged).toMatchObject({ status: "staged", profile });
+    const active = await profiles.activate("acme", staged.profileDigest);
+    expect(active.status).toBe("active");
+    expect(await profiles.getActive("acme")).toMatchObject({
+      profileDigest: staged.profileDigest,
+      profile,
+    });
+
+    const shadow = await profiles.stage(
+      "acme",
+      {
+        ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+        id: "test-shadow",
+        version: 1,
+      },
+      { split: "validation", recallAt10: 1, ndcgAt10: 1 },
+    );
+    await profiles.setShadow("acme", shadow.profileDigest);
+    expect((await profiles.getShadow("acme"))?.profileDigest).toBe(shadow.profileDigest);
+
+    const resolved = await profiles.resolve({
+      organizationId: "acme",
+      subjectId: "u1",
+      groupIds: [],
+    });
+    expect("descriptor" in resolved && resolved.descriptor.profileDigest).toBe(
+      staged.profileDigest,
+    );
+    await profiles.setCanaryPercent("acme", 0);
+    expect(
+      "descriptor" in
+        (await profiles.resolve({
+          organizationId: "acme",
+          subjectId: "u1",
+          groupIds: [],
+        })),
+    ).toBe(false);
+    await profiles.setCanaryPercent("acme", 100);
+
+    await profiles.activate("acme", shadow.profileDigest);
+    expect(await profiles.getShadow("acme")).toBeNull();
+    expect((await profiles.rollback("acme", staged.profileDigest)).profileDigest).toBe(
+      staged.profileDigest,
+    );
   });
 
   it("deduplicates and leases extraction jobs by resource, content, and ontology hashes", async () => {
@@ -177,6 +239,7 @@ describe.runIf(pool !== null)("PostgreSQL adapters", () => {
       });
       const retriever = new BidirectionalNLayerRetriever(
         new PostgresKnowledgeSearchGraph(countingPool, contents, [vectorIndex]),
+        new CalibratedTraversalScorePolicy(DEFAULT_CALIBRATED_SCORING_PROFILE),
       );
       const result = await retriever.retrieve({
         question: "Was order 42 paid?",
@@ -214,6 +277,7 @@ describe.runIf(pool !== null)("PostgreSQL adapters", () => {
     await deployments.activate("acme", "ontology-v1");
     const retriever = new BidirectionalNLayerRetriever(
       new PostgresKnowledgeSearchGraph(requiredPool(), contents),
+      new CalibratedTraversalScorePolicy(DEFAULT_CALIBRATED_SCORING_PROFILE),
     );
 
     const allowed = await retriever.retrieve({

--- a/packages/postgres/tests/postgres-scoring-profiles.test.ts
+++ b/packages/postgres/tests/postgres-scoring-profiles.test.ts
@@ -1,0 +1,270 @@
+import {
+  DEFAULT_CALIBRATED_SCORING_PROFILE,
+  type TraversalScoringProfile,
+  scoringProfileDigest,
+} from "@kontext-brain/core";
+import type { Pool, PoolClient, QueryResultRow } from "pg";
+import { describe, expect, it, vi } from "vitest";
+import { PostgresScoringProfileRepository } from "../src/index.js";
+
+const forbiddenPool = {
+  async connect(): Promise<never> {
+    throw new Error("database must not be consulted");
+  },
+} as unknown as Pool;
+
+interface RuntimeState {
+  activeDigest: string | null;
+  shadowDigest: string | null;
+  canaryPercent: number;
+}
+
+function fakeScoringDatabase() {
+  const profiles = new Map<string, QueryResultRow>();
+  const runtimes = new Map<string, RuntimeState>();
+  const release = vi.fn();
+  const runtimeFor = (organizationId: string): RuntimeState => {
+    const existing = runtimes.get(organizationId);
+    if (existing) return existing;
+    const created = { activeDigest: null, shadowDigest: null, canaryPercent: 100 };
+    runtimes.set(organizationId, created);
+    return created;
+  };
+  const result = (rows: QueryResultRow[]) => ({ rows, rowCount: rows.length });
+  const client = {
+    async query(statement: string, values: readonly unknown[] = []) {
+      const sql = statement.replace(/\s+/g, " ").trim();
+      if (
+        ["BEGIN", "BEGIN READ ONLY", "COMMIT", "ROLLBACK"].includes(sql) ||
+        sql.startsWith("SELECT set_config") ||
+        sql.startsWith("INSERT INTO kontext_organizations")
+      ) {
+        return result([]);
+      }
+      const organizationId = String(values[0]);
+      if (
+        sql.startsWith("INSERT INTO kontext_organization_runtime") &&
+        sql.includes("scoring_canary_percent")
+      ) {
+        runtimeFor(organizationId).canaryPercent = Number(values[1]);
+        return result([]);
+      }
+      if (sql.includes("LEFT JOIN kontext_scoring_profiles")) {
+        const runtime = runtimes.get(organizationId);
+        if (!runtime) return result([]);
+        const row = runtime.activeDigest
+          ? profiles.get(`${organizationId}:${runtime.activeDigest}`)
+          : undefined;
+        return result([
+          {
+            ...(row ?? {}),
+            scoring_canary_percent: runtime.canaryPercent,
+          },
+        ]);
+      }
+      if (sql.includes("runtime.active_scoring_profile_digest")) {
+        const runtime = runtimes.get(organizationId);
+        const row = runtime?.activeDigest
+          ? profiles.get(`${organizationId}:${runtime.activeDigest}`)
+          : undefined;
+        return result(row ? [row] : []);
+      }
+      if (sql.includes("runtime.shadow_scoring_profile_digest")) {
+        const runtime = runtimes.get(organizationId);
+        const row = runtime?.shadowDigest
+          ? profiles.get(`${organizationId}:${runtime.shadowDigest}`)
+          : undefined;
+        return result(row ? [row] : []);
+      }
+      throw new Error(`Unhandled scoring repository SQL: ${sql}`);
+    },
+    release,
+  } as unknown as PoolClient;
+  const pool = { connect: vi.fn(async () => client) } as unknown as Pool;
+
+  const putProfile = (
+    organizationId: string,
+    profile: TraversalScoringProfile,
+    status: "staged" | "active" | "retired" | "failed" = "active",
+  ): string => {
+    const digest = scoringProfileDigest(profile);
+    profiles.set(`${organizationId}:${digest}`, {
+      organization_id: organizationId,
+      profile_id: profile.id,
+      version: profile.version,
+      feature_schema_version: profile.featureSchemaVersion,
+      profile_digest: digest,
+      profile_data: profile,
+      evaluation_summary: { split: "validation" },
+      status,
+      failure: null,
+      created_at: "2026-08-25T00:00:00.000Z",
+    });
+    return digest;
+  };
+  const setActive = (organizationId: string, digest: string | null, canaryPercent = 100) => {
+    const runtime = runtimeFor(organizationId);
+    runtime.activeDigest = digest;
+    runtime.canaryPercent = canaryPercent;
+  };
+
+  return { pool, profiles, runtimes, runtimeFor, putProfile, setActive };
+}
+
+function resolvedProfileId(
+  policy: Awaited<ReturnType<PostgresScoringProfileRepository["resolve"]>>,
+): string {
+  return "descriptor" in policy ? policy.descriptor.profileId : "legacy-v1";
+}
+
+describe("PostgresScoringProfileRepository", () => {
+  it.each([-1, 101, 0.5, Number.NaN])(
+    "rejects invalid canary percentage %s before opening a transaction",
+    async (percent) => {
+      const repository = new PostgresScoringProfileRepository(forbiddenPool);
+
+      await expect(repository.setCanaryPercent("acme", percent)).rejects.toThrow(
+        "Scoring canary percent must be an integer between 0 and 100",
+      );
+    },
+  );
+
+  it("rejects an invalid profile before opening a transaction", async () => {
+    const repository = new PostgresScoringProfileRepository(forbiddenPool);
+    const invalidProfile = {
+      ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+      seed: {
+        ...DEFAULT_CALIBRATED_SCORING_PROFILE.seed,
+        exactMatchScore: 1.1,
+      },
+    };
+
+    await expect(repository.stage("acme", invalidProfile)).rejects.toThrow(
+      "profile.seed.exactMatchScore must be between zero and one",
+    );
+  });
+
+  it("uses the compatibility policy when an Organization has no active profile", async () => {
+    const database = fakeScoringDatabase();
+    const repository = new PostgresScoringProfileRepository(database.pool);
+
+    const resolved = await repository.resolve({
+      organizationId: "acme",
+      subjectId: "user:1",
+      groupIds: [],
+    });
+
+    expect(resolvedProfileId(resolved)).toBe("legacy-v1");
+  });
+
+  it("keeps subjects in a deterministic canary cohort", async () => {
+    const database = fakeScoringDatabase();
+    const profile = {
+      ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+      id: "canary-profile",
+      version: 2,
+    };
+    database.setActive("acme", database.putProfile("acme", profile), 50);
+    const repository = new PostgresScoringProfileRepository(database.pool);
+
+    const selected = await repository.resolve({
+      organizationId: "acme",
+      subjectId: "user:2",
+      groupIds: [],
+    });
+    const fallback = await repository.resolve({
+      organizationId: "acme",
+      subjectId: "user:1",
+      groupIds: [],
+    });
+    const selectedAgain = await repository.resolve({
+      organizationId: "acme",
+      subjectId: "user:2",
+      groupIds: ["different-groups-do-not-change-the-cohort"],
+    });
+
+    expect(resolvedProfileId(selected)).toBe("canary-profile");
+    expect(resolvedProfileId(fallback)).toBe("legacy-v1");
+    expect(resolvedProfileId(selectedAgain)).toBe("canary-profile");
+  });
+
+  it("keeps the active profile stable for the cache TTL and reloads it after expiry", async () => {
+    const database = fakeScoringDatabase();
+    const firstProfile = {
+      ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+      id: "active-v1",
+      version: 1,
+    };
+    const secondProfile = {
+      ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+      id: "active-v2",
+      version: 2,
+    };
+    const firstDigest = database.putProfile("acme", firstProfile);
+    const secondDigest = database.putProfile("acme", secondProfile);
+    database.setActive("acme", firstDigest);
+    let now = 1_000;
+    const repository = new PostgresScoringProfileRepository(
+      database.pool,
+      100,
+      undefined,
+      () => now,
+    );
+    const principal = { organizationId: "acme", subjectId: "user:1", groupIds: [] };
+
+    expect(resolvedProfileId(await repository.resolve(principal))).toBe("active-v1");
+    database.setActive("acme", secondDigest);
+    now = 1_099;
+    expect(resolvedProfileId(await repository.resolve(principal))).toBe("active-v1");
+    now = 1_101;
+    expect(resolvedProfileId(await repository.resolve(principal))).toBe("active-v2");
+  });
+
+  it("invalidates the active cache when the canary percentage changes", async () => {
+    const database = fakeScoringDatabase();
+    const profile = {
+      ...DEFAULT_CALIBRATED_SCORING_PROFILE,
+      id: "active-canary",
+      version: 2,
+    };
+    database.setActive("acme", database.putProfile("acme", profile));
+    const repository = new PostgresScoringProfileRepository(database.pool, 60_000);
+    const principal = { organizationId: "acme", subjectId: "user:2", groupIds: [] };
+
+    expect(resolvedProfileId(await repository.resolve(principal))).toBe("active-canary");
+    await repository.setCanaryPercent("acme", 0);
+    expect(resolvedProfileId(await repository.resolve(principal))).toBe("legacy-v1");
+    await repository.setCanaryPercent("acme", 100);
+    expect(resolvedProfileId(await repository.resolve(principal))).toBe("active-canary");
+  });
+
+  it("rejects an active row whose feature schema column disagrees with its profile", async () => {
+    const database = fakeScoringDatabase();
+    const digest = database.putProfile("acme", DEFAULT_CALIBRATED_SCORING_PROFILE);
+    const key = `acme:${digest}`;
+    database.profiles.set(key, {
+      ...database.profiles.get(key),
+      feature_schema_version: "corrupted-schema",
+    });
+    database.setActive("acme", digest);
+    const repository = new PostgresScoringProfileRepository(database.pool);
+
+    await expect(repository.getActive("acme")).rejects.toThrow(
+      "Scoring profile feature schema column does not match profile data",
+    );
+  });
+
+  it("rejects an active row whose stored digest disagrees with its profile", async () => {
+    const database = fakeScoringDatabase();
+    const digest = database.putProfile("acme", DEFAULT_CALIBRATED_SCORING_PROFILE);
+    const key = `acme:${digest}`;
+    database.profiles.set(key, {
+      ...database.profiles.get(key),
+      profile_digest: "sha256:corrupted",
+    });
+    database.setActive("acme", digest);
+    const repository = new PostgresScoringProfileRepository(database.pool);
+
+    await expect(repository.getActive("acme")).rejects.toThrow("Scoring profile digest mismatch");
+  });
+});

--- a/packages/postgres/tests/postgres-search-session.test.ts
+++ b/packages/postgres/tests/postgres-search-session.test.ts
@@ -202,6 +202,6 @@ describe("PostgresSearchSession", () => {
     expect(ontologySeeds.map((seed) => seed.node.id)).toEqual(
       ontologyNodes.slice(0, 12).map((node) => node.id),
     );
-    expect(ontologySeeds.every((seed) => seed.score === 0.08)).toBe(true);
+    expect(ontologySeeds.every((seed) => seed.observations?.fallback === true)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- replace fixed traversal weights with versioned observation-based scoring and query-local route gating
- add PostgreSQL profile persistence with shadow, canary, activation, and rollback support
- add matched direct-only and source-hydrated evaluations, then document the measured recall/precision tradeoff in README and ADRs

## Validation
- core, postgres, and benchmark TypeScript checks passed
- root tests: 146 passed, 9 skipped
- benchmark tests: 116 passed
- changed TypeScript files pass Biome
- staged diff passes whitespace validation