### PR TITLE
Publish final clean latency reevaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,28 +54,28 @@ harnesses are not part of the current performance claim.
 
 All rows below use the frozen shared answer/judge contract. Retrieval is scored
 over the full dataset; answer quality uses the same deterministic 200-query
-sample. Higher is better. Embedding API cost is the cost represented by the
-embeddings used in each row; when a run reused an existing cache, its newly
-incurred cost is shown separately.
+sample. Higher is better. Embedding API cost is the total represented embedding
+usage available for each row (index plus measured query-time embeddings), not
+an index-only cost; when a run reused an existing cache, its newly incurred
+cost is shown separately. The detailed report splits index-build time and cost
+from query-time usage where the native framework recorded both boundaries.
 
 | Dataset | System | Recall@10 | nDCG@10 | Correctness | Strict faithfulness | Claim F1 | Citation F1 | Warm retrieval p95 | Query-to-answer p95 | Eval E2E p95 | Embedding API cost | Answer+judge LLM tokens/query (in/out) | LLM API-equivalent $/query |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Medical | **Kontext v15** | 0.8914 | 0.9689 | **0.9499** | **0.9614** | **0.8612** | **0.9583** | 7.77 s | 20.15 s | 97.65 s | **$0.008150 represented / $0 new**‡ | 45,150 / 1,277 | ≈$0.1593§ |
-| Medical | Kontext v13 default | 0.8923 | 0.9704 | 0.9461 | 0.9534 | 0.8550 | 0.9541 | 6.83 s | 18.60 s | 108.08 s† | $0.008150 | 45,148 / 1,344 | ≈$0.1606§ |
+| Medical | **Kontext v15** | 0.8914 | 0.9689 | **0.9499** | **0.9614** | **0.8612** | **0.9583** | 7.30 s | 19.20 s | 124.86 s | **$0.008150 represented / $0 new**‡ | 45,150 / 1,277 | ≈$0.1593§ |
+| Medical | Kontext v13 default | 0.8923 | 0.9704 | 0.9461 | 0.9534 | 0.8550 | 0.9541 | 6.83 s | 18.60 s | 107.71 s | $0.008150 | 45,148 / 1,344 | ≈$0.1606§ |
 | Medical | LightRAG 1.5.6 | **0.9326** | 0.9990* | 0.8939 | 0.9417 | 0.8575 | 0.9477 | 6.00 s | 16.22 s | 123.02 s | $0.015409 | 57,911 / 1,651 | ≈$0.2057§ |
-| Medical | Microsoft GraphRAG 3.1.1 | 0.8303 | 0.9971* | 0.7817 | 0.8740 | 0.7336 | 0.8518 | 0.28 s | 12.83 s | 123.08 s† | $0.013623 | 43,402 / 1,942 | ≈$0.1678§ |
-| Novel | **Kontext v15** | 0.8209 | 0.9349 | **0.8566** | **0.9290** | **0.8234** | 0.9369 | 9.26 s | 20.15 s | 103.18 s | $0.029414¶ | 47,690 / 1,374 | ≈$0.1688§ |
-| Novel | Kontext v13 default | 0.5259 | 0.6662 | 0.4654 | 0.7922 | 0.5181 | 0.5521 | 10.13 s | 18.87 s | 83.62 s† | $0.017840 | 47,508 / 1,088 | ≈$0.1629§ |
+| Medical | Microsoft GraphRAG 3.1.1 | 0.8303 | 0.9971* | 0.7817 | 0.8740 | 0.7336 | 0.8518 | 0.28 s | 12.83 s | 113.19 s | $0.013623 | 43,402 / 1,942 | ≈$0.1678§ |
+| Novel | **Kontext v15** | 0.8209 | 0.9349 | **0.8566** | **0.9290** | **0.8234** | 0.9369 | 8.54 s | 20.11 s | 97.68 s | $0.029414¶ | 47,690 / 1,374 | ≈$0.1688§ |
+| Novel | Kontext v13 default | 0.5259 | 0.6662 | 0.4654 | 0.7922 | 0.5181 | 0.5521 | 9.89 s | 19.37 s | 83.51 s | $0.017840 | 47,508 / 1,088 | ≈$0.1629§ |
 | Novel | LightRAG 1.5.6 | **0.8567** | 0.9945* | 0.8498 | 0.9272 | 0.8201 | **0.9407** | 6.66 s | 17.88 s | 117.30 s | $0.049371 | 58,705 / 1,351 | ≈$0.2022§ |
-| Novel | Microsoft GraphRAG 3.1.1 | 0.7716 | 0.9816* | 0.7668 | 0.8651 | 0.7434 | 0.8763 | 0.40 s | 10.97 s | 140.49 s† | $0.088326 | 43,492 / 1,653 | ≈$0.1624§ |
+| Novel | Microsoft GraphRAG 3.1.1 | 0.7716 | 0.9816* | 0.7668 | 0.8651 | 0.7434 | 0.8763 | 0.40 s | 10.97 s | 136.36 s | $0.088326 | 43,492 / 1,653 | ≈$0.1624§ |
 
 Context precision is deliberately omitted from this compact table. `*` marks
 package-sensitive nDCG: LightRAG and Microsoft GraphRAG package a large native
 context as one evidence record, while Kontext exposes separately scored evidence
-windows, so their raw ranking/noise values are not directly comparable. `†`
-marks a judge stage that did not complete all 200 queries, which disqualifies
-only that row's Eval E2E figure and never its retrieval or query-to-answer
-latency. `‡` means the Medical v15 row represents the same 407,518 embedding
+windows, so their raw ranking/noise values are not directly comparable. `‡`
+means the Medical v15 row represents the same 407,518 embedding
 input tokens already paid for by the v13 run: 1,385 document, 2,062 query, and
 5,893 expanded-query vectors were reused, with zero new vectors or embedding
 input tokens. A fresh index or new query workload is not free. `¶` is the
@@ -96,9 +96,10 @@ SciFact/NFCorpus retrieval guardrails:
 
 #### How the three latency columns were measured
 
-The latency columns come from the 2026-08-24/27 clean latency campaign
-(protocol `clean-latency-v1.1`, artifacts under
-`bench/data/rag-eval-v2/runs/clean-latency-2026-08-24/`). They replace the
+The latency columns come from the 2026-08-24/29 clean latency campaign
+(protocol `clean-latency-v1.1`; accepted composite suite under
+`bench/data/rag-eval-v2/runs/clean-latency-corrective-attempt6-2026-08-28/`).
+Earlier invalid attempts remain preserved beside it. These values replace the
 earlier speed figures outright rather than adjusting them, because several of
 those were measured while other benchmarks shared one local Codex queue and so
 recorded other jobs' queue wait. Novel Kontext v15 previously read 972.11 s and
@@ -112,9 +113,9 @@ deterministic 200-query sample per dataset (seed 20260814, one shared sample
 digest), one system runs at a time, and retrieval, answer, and judge each run at
 concurrency 1, batch size 1, with no retries. Percentiles are nearest-rank.
 
-- **Warm retrieval p95** is retrieval only. Index construction is excluded; its
-  cost and wall-clock time live in the Embedding API cost column and in
-  [Benchmark history](./bench/data/BENCHMARK_HISTORY.md).
+- **Warm retrieval p95** is retrieval only. Index construction is excluded;
+  recorded index-build time and cost are reported separately in the detailed
+  comparison rather than folded into request latency.
 - **Query-to-answer p95** is retrieval plus answer latency. This is the
   user-facing number: the judge is an evaluation step, not part of answering.
 - **Eval E2E p95** adds the judge call and describes the evaluation pipeline

--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ harnesses are not part of the current performance claim.
 
 All rows below use the frozen shared answer/judge contract. Retrieval is scored
 over the full dataset; answer quality uses the same deterministic 200-query
-sample. Higher is better.
+sample. Higher is better. Embedding API cost is the cost represented by the
+embeddings used in each row; when a run reused an existing cache, its newly
+incurred cost is shown separately.
 
 | Dataset | System | Recall@10 | nDCG@10 | Correctness | Strict faithfulness | Claim F1 | Citation F1 | Warm retrieval p95 | Query-to-answer p95 | Eval E2E p95 | Embedding API cost | Answer+judge LLM tokens/query (in/out) | LLM API-equivalent $/query |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Medical | **Kontext v15** | 0.8914 | 0.9689 | **0.9499** | **0.9614** | **0.8612** | **0.9583** | 7.77 s | 20.15 s | 97.65 s | **$0 incremental**‡ | 45,150 / 1,277 | ≈$0.1593§ |
+| Medical | **Kontext v15** | 0.8914 | 0.9689 | **0.9499** | **0.9614** | **0.8612** | **0.9583** | 7.77 s | 20.15 s | 97.65 s | **$0.008150 represented / $0 new**‡ | 45,150 / 1,277 | ≈$0.1593§ |
 | Medical | Kontext v13 default | 0.8923 | 0.9704 | 0.9461 | 0.9534 | 0.8550 | 0.9541 | 6.83 s | 18.60 s | 108.08 s† | $0.008150 | 45,148 / 1,344 | ≈$0.1606§ |
 | Medical | LightRAG 1.5.6 | **0.9326** | 0.9990* | 0.8939 | 0.9417 | 0.8575 | 0.9477 | 6.00 s | 16.22 s | 123.02 s | $0.015409 | 57,911 / 1,651 | ≈$0.2057§ |
 | Medical | Microsoft GraphRAG 3.1.1 | 0.8303 | 0.9971* | 0.7817 | 0.8740 | 0.7336 | 0.8518 | 0.28 s | 12.83 s | 123.08 s† | $0.013623 | 43,402 / 1,942 | ≈$0.1678§ |
@@ -73,10 +75,13 @@ context as one evidence record, while Kontext exposes separately scored evidence
 windows, so their raw ranking/noise values are not directly comparable. `†`
 marks a judge stage that did not complete all 200 queries, which disqualifies
 only that row's Eval E2E figure and never its retrieval or query-to-answer
-latency. `‡` is the v15 marginal run cost after reusing
-the $0.008150 v13 Medical embedding index. `¶` is the preserved pre-fix v15
-Novel run cost; its whole-batch cache invalidation was fixed but the benchmark
-was not rerun to manufacture a cheaper number. `§` is an API-equivalent estimate
+latency. `‡` means the Medical v15 row represents the same 407,518 embedding
+input tokens already paid for by the v13 run: 1,385 document, 2,062 query, and
+5,893 expanded-query vectors were reused, with zero new vectors or embedding
+input tokens. A fresh index or new query workload is not free. `¶` is the
+preserved pre-fix v15 Novel run cost; its whole-batch cache invalidation was
+fixed but the benchmark was not rerun to manufacture a cheaper number. `§` is
+an API-equivalent estimate
 from the preserved stage-specific tokens, treating all input as uncached: answer
 GPT-5.6 Terra at $2 input/$12 output and judge GPT-5.6 Sol at $4 input/$20 output
 per million tokens, using the

--- a/bench/data/rag-eval-v2/cross-framework-all-datasets-2026-08-23.md
+++ b/bench/data/rag-eval-v2/cross-framework-all-datasets-2026-08-23.md
@@ -47,10 +47,10 @@ same 200/200 answer and judgement sample with zero errors.
 
 | System | Recall@10 | nDCG@10 | Raw/package-sensitive CP | Correctness | Strict faith | Claim F1 | Citation F1 | Warm retrieval p95 | Query-to-answer p95 | Eval E2E p95 |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| **Kontext v15** | **0.891368** | 0.968907 | **0.580861** | **0.949917** | **0.961385** | **0.861159** | **0.958348** | 7.77 s | 20.15 s | 97.65 s |
-| Kontext v13 | 0.892338 | 0.970428 | 0.580222 | 0.946127 | 0.953411 | 0.855016 | 0.954141 | 6.83 s | 18.60 s | 108.08 s† |
+| **Kontext v15** | **0.891368** | 0.968907 | **0.580861** | **0.949917** | **0.961385** | **0.861159** | **0.958348** | 7.30 s | 19.20 s | 124.86 s |
+| Kontext v13 | 0.892338 | 0.970428 | 0.580222 | 0.946127 | 0.953411 | 0.855016 | 0.954141 | 6.83 s | 18.60 s | 107.71 s |
 | LightRAG 1.5.6 | 0.932590 | 0.999030* | 0.999030* | 0.893900 | 0.941683 | 0.857511 | 0.947662 | 6.00 s | 16.22 s | 123.02 s |
-| Microsoft GraphRAG 3.1.1 | 0.830262 | 0.997090* | 0.997090* | 0.781650 | 0.873956 | 0.733552 | 0.851768 | 0.28 s | 12.83 s | 123.08 s† |
+| Microsoft GraphRAG 3.1.1 | 0.830262 | 0.997090* | 0.997090* | 0.781650 | 0.873956 | 0.733552 | 0.851768 | 0.28 s | 12.83 s | 113.19 s |
 | Vector + BM25-RRF | 0.706596 | 0.743378 | 0.381232 | 0.873801 | 0.895057 | 0.807975 | 0.899981 | not re-measured | not re-measured | not re-measured |
 
 `*` LightRAG and Microsoft GraphRAG package a large native context as one
@@ -60,10 +60,11 @@ evidence windows.
 
 Relative to LightRAG, v15 has -0.041222 recall but +0.056017 correctness,
 +0.019702 strict faithfulness, +0.003649 claim F1, and +0.010686 citation F1.
-It is 1.3x slower on warm retrieval p95 and 1.2x slower on query-to-answer p95,
-and 1.3x faster on the judge-inclusive Eval E2E p95. Relative to Microsoft
+It is 1.2x slower on warm retrieval p95 and 1.2x slower on query-to-answer p95,
+and 1.02x slower on the judge-inclusive Eval E2E p95. Relative to Microsoft
 GraphRAG, v15 improves recall by 0.061106 and correctness by 0.168267 while
-being 27.8x slower on warm retrieval p95 and 1.6x slower on query-to-answer p95.
+being 26.1x slower on warm retrieval p95, 1.5x slower on query-to-answer p95,
+and 1.1x slower on judge-inclusive Eval E2E p95.
 
 An earlier revision of this report claimed v15's retrieval p95 was 11.1x lower
 than LightRAG's. That comparison came from queue-contended timings and its
@@ -88,10 +89,10 @@ judgement sample with zero errors.
 
 | System | Recall@10 | nDCG@10 | Raw/package-sensitive CP | Correctness | Strict faith | Claim F1 | Citation F1 | Warm retrieval p95 | Query-to-answer p95 | Eval E2E p95 |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| **Kontext v15** | **0.820896** | 0.934913 | **0.449236** | **0.856572** | **0.929011** | **0.823365** | 0.936913 | 9.26 s | 20.15 s | 103.18 s |
-| Kontext v13 | 0.525871 | 0.666185 | 0.289687 | 0.465432 | 0.792182 | 0.518112 | 0.552107 | 10.13 s | 18.87 s | 83.62 s† |
+| **Kontext v15** | **0.820896** | 0.934913 | **0.449236** | **0.856572** | **0.929011** | **0.823365** | 0.936913 | 8.54 s | 20.11 s | 97.68 s |
+| Kontext v13 | 0.525871 | 0.666185 | 0.289687 | 0.465432 | 0.792182 | 0.518112 | 0.552107 | 9.89 s | 19.37 s | 83.51 s |
 | LightRAG 1.5.6 | 0.856716 | 0.994527* | 0.994527* | 0.849765 | 0.927176 | 0.820114 | **0.940739** | 6.66 s | 17.88 s | 117.30 s |
-| Microsoft GraphRAG 3.1.1 | 0.771642 | 0.981592* | 0.981592* | 0.766762 | 0.865095 | 0.743363 | 0.876322 | 0.40 s | 10.97 s | 140.49 s† |
+| Microsoft GraphRAG 3.1.1 | 0.771642 | 0.981592* | 0.981592* | 0.766762 | 0.865095 | 0.743363 | 0.876322 | 0.40 s | 10.97 s | 136.36 s |
 
 v15 versus v13 improves recall by 0.295025 and correctness by 0.391141. It
 also edges LightRAG on correctness (+0.006807), strict faithfulness
@@ -99,13 +100,13 @@ also edges LightRAG on correctness (+0.006807), strict faithfulness
 citation F1 by 0.003826. It exceeds Microsoft GraphRAG on every reported
 quality metric except the incomparable packaged context precision.
 
-`†` marks a judge stage that did not complete all 200 queries, which
-disqualifies only that row's Eval E2E figure. Retrieval and query-to-answer
-latency are unaffected, because the judge never enters them.
+Against LightRAG, Novel v15 is 1.28x slower on warm retrieval and 1.12x slower
+on query-to-answer, but 1.20x faster on judge-inclusive Eval E2E p95.
 
-The three latency columns come from the 2026-08-24/27 clean latency campaign
-(protocol `clean-latency-v1.1`, artifacts under
-`runs/clean-latency-2026-08-24/`), which replaced the earlier queue-contended
+The three latency columns come from the 2026-08-24/29 clean latency campaign
+(protocol `clean-latency-v1.1`; accepted composite suite under
+`runs/clean-latency-corrective-attempt6-2026-08-28/`), which replaced the
+earlier queue-contended
 timings rather than adjusting them. Warm retrieval p95 excludes index
 construction; query-to-answer p95 adds the answer call and is the user-facing
 figure; Eval E2E p95 adds the judge and describes the evaluation pipeline only.
@@ -146,7 +147,7 @@ needed by the newer score contract.
 | SciFact | Kontext v13 | 300/300 | 0.960000 | 0.824401 | 0.034686 | 38.71 s |
 | SciFact | Vector + BM25-RRF | 300/300 | 0.822444 | 0.706630 | 0.163667 | 0.017 s |
 | SciFact | LightRAG 1.5.6 | 300/300 | 0.149667 | 0.166667* | 0.166667* | 714.31 s |
-| SciFact | Microsoft GraphRAG 3.1.1 | indexing | — | — | — | — |
+| SciFact | Microsoft GraphRAG 3.1.1 | 300/300 | 0.685833 | 0.706667* | 0.706667* | 0.448 s |
 | NFCorpus | **Kontext v15** | 323/323 | **0.279016** | 0.366554 | 0.174420 | 57.88 s |
 | NFCorpus | Kontext v13 | 323/323 | 0.278486 | 0.368195 | 0.174640 | 57.26 s |
 | NFCorpus | Vector + BM25-RRF | 323/323 | 0.162923 | 0.331071 | 0.308978 | 0.015 s |
@@ -160,9 +161,17 @@ retrieval process started 13 minutes before the same provenance contract was
 committed, so its source-less output is likewise preserved as
 `retrieval.pre-provenance-2026-08-24.jsonl`. The completed native index was
 reused without rebuilding; a fresh retrieval process produced 323/323 rows
-with 4,644 official source IDs before the score above was generated. The
-Microsoft SciFact row will be filled only after its native graph index and
-retrieval complete.
+with 4,644 official source IDs before the score above was generated.
+
+Microsoft SciFact also completed 300/300 native retrievals. Its immutable
+pre-contract output stored official IDs inside every native evidence text but
+not in the top-level `sourceIds` field expected by the scorer. A deterministic
+provenance replay applied the adapter's existing extraction contract to that
+same file: no retrieval, model, embedding, or index call was made; all 300 rows
+received source IDs (4,481 IDs total), and the original retrieval file was left
+unchanged. The score above is recorded in
+`retrieval-score.provenance-replay-2026-08-29.json`, with the input/output
+digests and zero-call boundary in `provenance-replay-2026-08-29.json`.
 
 ## Answer/judge tokens and API-equivalent cost
 
@@ -222,6 +231,7 @@ without its validated v13 source cache.
 | SciFact / v15 newly incurred | **0** | **$0** | 6,364 vectors reused; 0 new |
 | SciFact / Vector baseline | 1,693,048 | $0.033861 | Native vector index |
 | SciFact / LightRAG | 815,880 | $0.016318 | Native-index usage log |
+| SciFact / Microsoft GraphRAG | 9,476,780 | $0.189536 | 9,470,864 index tokens/$0.189417 + 5,916 retrieval-query tokens/$0.000118; local completion tokens unmetered |
 | NFCorpus / Kontext v13 base | 1,253,777 | $0.025076 | Original reusable index |
 | NFCorpus / v15 newly incurred | **0** | **$0** | 4,645 vectors reused; 0 new |
 | NFCorpus / Vector baseline | 1,283,605 | $0.025672 | Native vector index |
@@ -232,6 +242,30 @@ The embedding table above reports the separately auditable OpenAI embedding API
 charge. The answer/judge table reports the stage-aware API-equivalent LLM cost;
 Kontext's local-CLI query-expansion and reranker calls were not fully metered and
 are excluded rather than estimated.
+
+### Index-build time and cost boundary
+
+Microsoft GraphRAG records active pipeline runtime separately from retrieval.
+The values below are its `stats.total_runtime`, not wall elapsed time including
+intentional pauses or restarts. Kontext and LightRAG did not preserve a
+comparable build timer for these runs, so their cells remain “not recorded”
+rather than being inferred from file times. Completion work used the local
+Codex CLI; its token telemetry was unavailable and no API-equivalent completion
+cost is estimated.
+
+| Dataset / system | Active index-build time | Index embedding tokens | Index embedding cost | Other index LLM boundary |
+|---|---:|---:|---:|---|
+| Medical / Microsoft GraphRAG | 1h 37m 53s | 643,800 | $0.012876 | Local completion cost unmetered |
+| Novel / Microsoft GraphRAG | 25h 08m 45s | 4,189,891 | $0.083798 | Local completion cost unmetered |
+| SciFact / Microsoft GraphRAG | 9h 36m 09s | 9,470,864 | $0.189417 | 22,770 local completion requests; token cost unmetered |
+| NFCorpus / Microsoft GraphRAG | 23h 15m 36s | 5,506,192 | $0.110124 | Local completion cost unmetered |
+| Kontext / all reported datasets | not recorded | See represented/marginal usage table | See represented/marginal usage table | Not inferred |
+| LightRAG / all reported datasets | not recorded | See represented usage table | See represented usage table | Not inferred |
+
+Query embeddings and warm retrieval latency are excluded from this index-build
+table. For SciFact Microsoft GraphRAG, the later retrieval used 5,916 embedding
+tokens ($0.000118), while the index pipeline used the 9,470,864 tokens shown
+above. The clean-latency table reused completed indexes and incurred no build.
 
 The original v15 Novel run revealed a cache transport defect: adding nine
 missing resources changed a whole-corpus digest and invalidated otherwise


### PR DESCRIPTION
## Clean latency re-measurement (2026-08-24 → 29)

Follow-up to merged PR #5. That PR's description has also been updated with the
final audit, but these two post-merge documentation commits need this separate
draft to enter `main`.

Replaces every speed figure in the README snapshot and cross-framework report
with measurements taken under a frozen protocol, and splits the old latency
boundary into three. No quality score changed: this campaign re-measured
latency only, on the same deterministic 200-query sample per dataset.

All eight accepted rows completed 200 retrievals, 200 answers, and 200 judges;
their retrieval/answer/judge assessments are all `valid`, and every warm index
source digest is unchanged.

| Dataset | System | Published retrieval p95 | Clean warm retrieval p95 | Clean query-to-answer p95 | Clean Eval E2E p95 |
|---|---|---:|---:|---:|---:|
| Medical | Kontext v15 | 34.05 s | **7.30 s** | **19.20 s** | 124.86 s |
| Medical | Kontext v13 | 34.94 s | **6.83 s** | **18.60 s** | 107.71 s |
| Medical | LightRAG 1.5.6 | 377.92 s | **6.00 s** | **16.22 s** | 123.02 s |
| Medical | MS GraphRAG 3.1.1 | 0.52 s | **0.28 s** | **12.83 s** | 113.19 s |
| Novel | Kontext v15 | 972.11 s | **8.54 s** | **20.11 s** | 97.68 s |
| Novel | Kontext v13 | 37.29 s | **9.89 s** | **19.37 s** | 83.51 s |
| Novel | LightRAG 1.5.6 | 3,386.57 s | **6.66 s** | **17.88 s** | 117.30 s |
| Novel | MS GraphRAG 3.1.1 | 0.47 s | **0.40 s** | **10.97 s** | 136.36 s |

### Why

The published speed column was contaminated. Several rows were measured while
other benchmarks shared one local Codex queue, so their per-query latency was
largely other jobs' queue wait — completions clustered in 15–20 minute waves,
with hundreds of queries above 600 s. Earlier invalid/corrective attempts remain
preserved; no rejected value was blended into the accepted suite.

### Protocol (`clean-latency-v1.1`)

- Warm index reuse only: no index build, no new embeddings, and cache miss
  fails closed.
- Same deterministic 200-query sample per dataset (seed 20260814), with one
  sample digest shared across all four systems in that dataset.
- One system at a time; retrieval, answer, and judge at concurrency 1, batch
  size 1, no retries. Percentiles are nearest-rank.
- **Warm retrieval p95** is retrieval only. **Query-to-answer p95** is retrieval
  plus answer and is the official user-facing figure. **Eval E2E p95** adds the
  judge and describes the evaluation pipeline only.
- Fail-closed for any latency above 600 s, queue/throttle/usage-limit error,
  10–20 minute completion wave, cache miss, provenance mismatch, or source
  mutation.
- Accepted composite artifacts are under
  `runs/clean-latency-corrective-attempt6-2026-08-28/`; prior invalid attempts
  are retained separately.

### Two measurement bugs fixed during the campaign (already merged in #5)

1. **Replayed expansion latency** (2f87ee9). A warm checkpoint hit was adding
   the stored latency from the run that first produced the expansion even
   though the hit spent no wall-clock time. Cache hits are now explicit and
   contribute zero expansion latency.
2. **Judge timeout above the validity threshold** (fa7d791). The protocol
   rejected latency above 600 s but the judge waited 1,800 s before giving up.
   The timeout now matches the tail limit.

Both fixes are covered by rag-eval tests.

### SciFact completion and provenance

Microsoft GraphRAG finished its native SciFact index and 300/300 retrievals.
The immutable pre-contract output placed official IDs inside native evidence
text but omitted the scorer's top-level `sourceIds`. A deterministic replay of
the existing adapter provenance contract recovered 4,481 IDs across all 300
rows without a retrieval, model, embedding, or index call and without changing
the original file. The official scorer reports Recall@10 0.685833, nDCG@10
0.706667, context precision 0.706667, and retrieval p95 0.448 s; input/output
digests and the zero-call boundary are recorded beside the replay score.

The original checkpoint required resuming PID 11944 before PID 12441. At final
audit PID 11944 was absent, while PID 12441 and the later same-index processes
remained stopped in PGID 11768. Because the prescribed identity/order could no
longer be verified and the completed index must not be mutated, no `SIGCONT`,
kill, or restart was sent. The fail-closed decision and exact process identities
are recorded in `scifact-resume-audit-2026-08-29.json`.

### Index-build time and cost stay separate

Warm request latency excludes indexing. The detailed report now gives
Microsoft GraphRAG's active `stats.total_runtime` and index-only embedding
boundary separately:

| Dataset | Active index time | Index embedding tokens | Index embedding cost |
|---|---:|---:|---:|
| Medical | 1h 37m 53s | 643,800 | $0.012876 |
| Novel | 25h 08m 45s | 4,189,891 | $0.083798 |
| SciFact | 9h 36m 09s | 9,470,864 | $0.189417 |
| NFCorpus | 23h 15m 36s | 5,506,192 | $0.110124 |

These are active pipeline times, not wall elapsed time including pauses.
SciFact retrieval added 5,916 query-embedding tokens ($0.000118). The index made
22,770 local completion requests, but completion-token telemetry was unavailable,
so no API-equivalent completion cost is fabricated. Kontext/LightRAG build time
is marked “not recorded” rather than inferred.

### Honest read of the result

Kontext does not win on speed. Medical user-facing latency spans 12.83–19.20 s.
Medical v15 is 1.22x slower than LightRAG on warm retrieval and 1.18x slower on
query-to-answer; it is 1.02x slower on judge-inclusive E2E. Against Microsoft
GraphRAG it is 26.1x slower on retrieval, 1.5x slower on query-to-answer, and
1.1x slower on Eval E2E. On Novel, v15 is 1.28x slower than LightRAG on warm
retrieval and 1.12x slower on query-to-answer, but 1.20x faster on Eval E2E.

The retrieval round trip still buys grounding quality: on Medical, v15 leads
LightRAG by 5.6 pp correctness, 2.0 pp strict faithfulness, and 1.1 pp citation
F1. On Novel the correctness margin is 0.7 pp, small enough that the rerank's
value on narrative corpora remains an open experiment.

### Verification

- Full rag-eval v2 suite: 20 files, 144 tests passed.
- TypeScript: all nine workspace/bench configurations passed `tsc --noEmit`.
- Biome: all 32 code/config files changed by this branch passed; the repository
  wide command still reports pre-existing generated-data formatting findings.
- `git diff --check`: passed.
