### PR TITLE
Make autoSetup infer ontology node count

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -326,7 +326,7 @@ pnpm --filter @kontext-brain/tool-server start kontext.yaml
 | `kontext_ingest` | `{ data, source? }` | entity를 추출해 graph에 적재 |
 | `kontext_describe` | `{}` | ontology, pipeline, MCP adapter 설명 |
 | `kontext_sync` | `{ connectorName? }` | 추가/변경분을 점진적으로 분류하고 삭제 resource 제거 |
-| `kontext_auto_setup` | `{ targetNodeCount? }` | LLM이 ontology를 생성/확장하고 문서를 분류 |
+| `kontext_auto_setup` | `{ targetNodeCount? }` | ontology 크기를 자동 추정(또는 override)하고 생성·분류 |
 
 ---
 
@@ -436,7 +436,7 @@ graph traversal은 기본값이 아니라 명시적 recall-first 옵션입니다
 
 ```typescript
 const agent = await KontextLoader.fromFile("kontext.yaml");
-const result = await agent.autoSetup({ targetNodeCount: 8 });
+const result = await agent.autoSetup();
 
 console.log(`Built ${result.nodesCreated} ontology nodes`);
 console.log(`Classified ${result.documentsClassified} documents`);
@@ -447,10 +447,11 @@ console.log(result.ontologyYaml);
 내부 절차:
 
 1. 모든 connector에서 `MCPConnector.listResources()` 호출
-2. `OntologyAutoBuilder.build()`가 category, parent/level hierarchy, edge를 생성
-3. `DocumentClassifier.classify()`가 각 document를 최적 node에 mapping하고 unmappable document에 대해 새 node 제안
-4. Node별 `MetaIndexStore.index()`
-5. Node description과 선택적 document body를 `VectorStore.upsert()`
+2. `OntologyAutoBuilder.build()`가 corpus 크기와 category 다양성으로 적절한 node 수를 자동 추정. 필요하면 `autoSetup(8)`처럼 숫자로 덮어쓸 수 있음
+3. LLM이 parent/level hierarchy와 edge를 생성
+4. `DocumentClassifier.classify()`가 각 document를 최적 node에 mapping하고 unmappable document에 대해 검토 가능한 새 node 제안 생성
+5. Node별 `MetaIndexStore.index()`
+6. Node description과 선택적 document body를 `VectorStore.upsert()`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ The server exposes 6 tools to the host agent:
 | `kontext_ingest` | `{ data, source? }` | extracts entities into the graph |
 | `kontext_describe` | `{}` | dumps ontology / pipeline / MCP adapters |
 | `kontext_sync` | `{ connectorName? }` | incrementally classify additions/changes and remove deleted resources |
-| `kontext_auto_setup` | `{ targetNodeCount? }` | LLM builds/expands ontology + classifies docs |
+| `kontext_auto_setup` | `{ targetNodeCount? }` | infers ontology size (or uses an override), builds it, and classifies docs |
 
 ---
 
@@ -660,7 +660,7 @@ sources:
 
 ```typescript
 const agent = await KontextLoader.fromFile("kontext.yaml");
-const result = await agent.autoSetup({ targetNodeCount: 8 });
+const result = await agent.autoSetup();
 
 console.log(`Built ${result.nodesCreated} ontology nodes`);
 console.log(`Classified ${result.documentsClassified} documents`);
@@ -671,12 +671,14 @@ console.log(result.ontologyYaml);  // save this back to kontext.yaml for reuse
 Internally:
 
 1. `MCPConnector.listResources()` on every connector → `MCPResourceInfo[]`
-2. `OntologyAutoBuilder.build()` — LLM extracts categories, designs N nodes
-   with parent/level hierarchy, infers edges
-3. `DocumentClassifier.classify()` — LLM maps each document to its best node;
-   any unmappable docs spawn new nodes
-4. `MetaIndexStore.index()` per node
-5. `VectorStore.upsert()` of node descriptions and (optionally) document bodies
+2. `OntologyAutoBuilder.build()` — LLM extracts categories; corpus size and
+   topic diversity determine a compact target node count automatically, unless
+   the caller supplies a numeric override such as `autoSetup(8)`
+3. The LLM designs nodes with parent/level hierarchy and infers edges
+4. `DocumentClassifier.classify()` — LLM maps each document to its best node;
+   unmappable documents create reviewable ontology proposals
+5. `MetaIndexStore.index()` per node
+6. `VectorStore.upsert()` of node descriptions and (optionally) document bodies
 
 The whole flow takes one network round-trip per LLM call, parallelized where
 safe. Total time: roughly 30 seconds for a 100-doc corpus on Claude Haiku;

--- a/examples/auto-setup/src/index.ts
+++ b/examples/auto-setup/src/index.ts
@@ -179,7 +179,7 @@ async function main(): Promise<void> {
 
   console.log("Before autoSetup:", agent.ontologyGraph.nodes.size, "nodes");
 
-  const setup = await agent.autoSetup(3);
+  const setup = await agent.autoSetup();
   console.log("\nautoSetup result:");
   console.log("  Nodes created:   ", setup.nodesCreated);
   console.log("  Docs classified: ", setup.documentsClassified);

--- a/packages/core/src/ingest/ontology-auto-builder.ts
+++ b/packages/core/src/ingest/ontology-auto-builder.ts
@@ -26,6 +26,23 @@ export const emptyOntologyBuildResult: OntologyBuildResult = {
   docCount: 0,
 };
 
+const MIN_AUTO_NODE_COUNT = 3;
+const MAX_AUTO_NODE_COUNT = 20;
+
+function inferTargetNodeCount(documentCount: number, categoryCount: number): number {
+  const maxUsefulNodeCount = Math.min(MAX_AUTO_NODE_COUNT, documentCount);
+  const minUsefulNodeCount = Math.min(MIN_AUTO_NODE_COUNT, maxUsefulNodeCount);
+  // Grow sublinearly with corpus size, while allowing diverse extracted topics
+  // to raise the target. Two related raw categories can share one ontology node.
+  const corpusSizeEstimate = Math.ceil(Math.sqrt(documentCount));
+  const topicDiversityEstimate = Math.ceil(categoryCount / 2);
+
+  return Math.min(
+    maxUsefulNodeCount,
+    Math.max(minUsefulNodeCount, corpusSizeEstimate, topicDiversityEstimate),
+  );
+}
+
 /**
  * Auto-builds an ontology (nodes + edges) from document sources.
  *
@@ -38,7 +55,7 @@ export const emptyOntologyBuildResult: OntologyBuildResult = {
 export class OntologyAutoBuilder {
   constructor(
     private readonly adapter: LLMAdapter,
-    private readonly targetNodeCount = 10,
+    private readonly targetNodeCount?: number,
     private readonly batchSize = 20,
     private readonly templates: PromptTemplates = DefaultPromptTemplates,
   ) {}
@@ -81,7 +98,11 @@ export class OntologyAutoBuilder {
     );
 
     try {
-      const clean = response.trim().replace(/^```json/, "").replace(/```$/, "").trim();
+      const clean = response
+        .trim()
+        .replace(/^```json/, "")
+        .replace(/```$/, "")
+        .trim();
       const parsed = JSON.parse(clean);
       if (Array.isArray(parsed)) return parsed.map((x) => String(x));
     } catch {
@@ -94,17 +115,26 @@ export class OntologyAutoBuilder {
     docs: readonly SourceDocument[],
     rawCategories: readonly string[],
   ): Promise<OntologyNode[]> {
-    const docTitles = docs.slice(0, 100).map((d) => `- ${d.title}`).join("\n");
+    const targetNodeCount =
+      this.targetNodeCount ?? inferTargetNodeCount(docs.length, rawCategories.length);
+    const docTitles = docs
+      .slice(0, 100)
+      .map((d) => `- ${d.title}`)
+      .join("\n");
     const catList = rawCategories.join(", ");
 
     const response = await this.adapter.complete(
-      this.templates.nodeDesign(this.targetNodeCount),
+      this.templates.nodeDesign(targetNodeCount),
       `Documents:\n${docTitles}\n\nExtracted categories: ${catList}`,
       "Design ontology nodes.",
     );
 
     try {
-      const clean = response.trim().replace(/^```json/, "").replace(/```$/, "").trim();
+      const clean = response
+        .trim()
+        .replace(/^```json/, "")
+        .replace(/```$/, "")
+        .trim();
       const parsed: unknown = JSON.parse(clean);
       if (typeof parsed !== "object" || parsed === null || !("nodes" in parsed)) return [];
       const rawNodes = (parsed as { nodes: unknown }).nodes;
@@ -116,8 +146,7 @@ export class OntologyAutoBuilder {
           description: String(n.description ?? ""),
           weight: typeof n.weight === "number" ? n.weight : 0.8,
           level: typeof n.level === "number" ? n.level : 0,
-          parentId:
-            parentId && parentId !== "null" && parentId !== null ? String(parentId) : null,
+          parentId: parentId && parentId !== "null" && parentId !== null ? String(parentId) : null,
         });
       });
     } catch {
@@ -136,7 +165,11 @@ export class OntologyAutoBuilder {
     );
 
     try {
-      const clean = response.trim().replace(/^```json/, "").replace(/```$/, "").trim();
+      const clean = response
+        .trim()
+        .replace(/^```json/, "")
+        .replace(/```$/, "")
+        .trim();
       const parsed: unknown = JSON.parse(clean);
       if (typeof parsed !== "object" || parsed === null || !("edges" in parsed)) return [];
       const rawEdges = (parsed as { edges: unknown }).edges;

--- a/packages/core/src/ingest/ontology-auto-builder.ts
+++ b/packages/core/src/ingest/ontology-auto-builder.ts
@@ -26,8 +26,17 @@ export const emptyOntologyBuildResult: OntologyBuildResult = {
   docCount: 0,
 };
 
-const MIN_AUTO_NODE_COUNT = 3;
-const MAX_AUTO_NODE_COUNT = 20;
+export const MIN_AUTO_NODE_COUNT = 3;
+export const MAX_AUTO_NODE_COUNT = 20;
+
+function assertValidTargetNodeCount(value: number): number {
+  if (!Number.isInteger(value) || value < MIN_AUTO_NODE_COUNT || value > MAX_AUTO_NODE_COUNT) {
+    throw new RangeError(
+      `targetNodeCount must be an integer between ${MIN_AUTO_NODE_COUNT} and ${MAX_AUTO_NODE_COUNT}`,
+    );
+  }
+  return value;
+}
 
 function inferTargetNodeCount(documentCount: number, categoryCount: number): number {
   const maxUsefulNodeCount = Math.min(MAX_AUTO_NODE_COUNT, documentCount);
@@ -116,7 +125,9 @@ export class OntologyAutoBuilder {
     rawCategories: readonly string[],
   ): Promise<OntologyNode[]> {
     const targetNodeCount =
-      this.targetNodeCount ?? inferTargetNodeCount(docs.length, rawCategories.length);
+      this.targetNodeCount === undefined
+        ? inferTargetNodeCount(docs.length, rawCategories.length)
+        : assertValidTargetNodeCount(this.targetNodeCount);
     const docTitles = docs
       .slice(0, 100)
       .map((d) => `- ${d.title}`)

--- a/packages/core/tests/ontology-auto-builder.test.ts
+++ b/packages/core/tests/ontology-auto-builder.test.ts
@@ -70,6 +70,15 @@ describe("OntologyAutoBuilder node-count selection", () => {
     expect(llm.nodeDesignPrompts[0]).toContain("design approximately 20 ontology nodes");
   });
 
+  it("rejects an explicit override outside the supported range", async () => {
+    for (const invalid of [0, -5, 2.5, 21]) {
+      const builder = new OntologyAutoBuilder(new CapturingLLM(), invalid);
+      await expect(
+        builder.build([new InMemoryDocumentSource(createDocuments(16))]),
+      ).rejects.toThrow(RangeError);
+    }
+  });
+
   it("keeps an explicit target node-count override", async () => {
     const llm = new CapturingLLM();
     const builder = new OntologyAutoBuilder(llm, 8);

--- a/packages/core/tests/ontology-auto-builder.test.ts
+++ b/packages/core/tests/ontology-auto-builder.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryDocumentSource, type LLMAdapter, OntologyAutoBuilder } from "../src/index.js";
+
+class CapturingLLM implements LLMAdapter {
+  readonly nodeDesignPrompts: string[] = [];
+
+  constructor(private readonly categories = ["Backend", "Frontend", "Security", "Operations"]) {}
+
+  async complete(systemPrompt: string): Promise<string> {
+    if (systemPrompt.includes("extract common topic categories")) {
+      return JSON.stringify(this.categories);
+    }
+    if (systemPrompt.includes("design approximately")) {
+      this.nodeDesignPrompts.push(systemPrompt);
+      return JSON.stringify({
+        nodes: [
+          { id: "Engineering", description: "software systems", level: 0 },
+          { id: "Operations", description: "deployments incidents", level: 0 },
+        ],
+      });
+    }
+    return JSON.stringify({ edges: [] });
+  }
+}
+
+function createDocuments(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `doc-${index}`,
+    title: `Document ${index}`,
+    metadata: {},
+  }));
+}
+
+describe("OntologyAutoBuilder node-count selection", () => {
+  it("infers the target from corpus size and topic diversity by default", async () => {
+    const llm = new CapturingLLM();
+    const builder = new OntologyAutoBuilder(llm);
+
+    await builder.build([new InMemoryDocumentSource(createDocuments(16))]);
+
+    expect(llm.nodeDesignPrompts).toHaveLength(1);
+    expect(llm.nodeDesignPrompts[0]).toContain("design approximately 4 ontology nodes");
+  });
+
+  it("does not infer more nodes than a small corpus can support", async () => {
+    const llm = new CapturingLLM();
+    const builder = new OntologyAutoBuilder(llm);
+
+    await builder.build([new InMemoryDocumentSource(createDocuments(2))]);
+
+    expect(llm.nodeDesignPrompts[0]).toContain("design approximately 2 ontology nodes");
+  });
+
+  it("increases the target when topic diversity exceeds the corpus-size signal", async () => {
+    const categories = Array.from({ length: 24 }, (_, index) => `Topic ${index}`);
+    const llm = new CapturingLLM(categories);
+    const builder = new OntologyAutoBuilder(llm);
+
+    await builder.build([new InMemoryDocumentSource(createDocuments(100))]);
+
+    expect(llm.nodeDesignPrompts[0]).toContain("design approximately 12 ontology nodes");
+  });
+
+  it("caps the automatically inferred target for large corpora", async () => {
+    const llm = new CapturingLLM();
+    const builder = new OntologyAutoBuilder(llm);
+
+    await builder.build([new InMemoryDocumentSource(createDocuments(625))]);
+
+    expect(llm.nodeDesignPrompts[0]).toContain("design approximately 20 ontology nodes");
+  });
+
+  it("keeps an explicit target node-count override", async () => {
+    const llm = new CapturingLLM();
+    const builder = new OntologyAutoBuilder(llm, 8);
+
+    await builder.build([new InMemoryDocumentSource(createDocuments(16))]);
+
+    expect(llm.nodeDesignPrompts).toHaveLength(1);
+    expect(llm.nodeDesignPrompts[0]).toContain("design approximately 8 ontology nodes");
+  });
+});

--- a/packages/loader/src/kontext-agent.ts
+++ b/packages/loader/src/kontext-agent.ts
@@ -272,7 +272,7 @@ export class KontextAgent {
       return emptySyncResult;
     }
     if (this.ontologySchemaGraph.nodes.size === 0) {
-      const setup = await this.autoSetupUnlocked(10, targets);
+      const setup = await this.autoSetupUnlocked(undefined, targets);
       return {
         connectorsSynced: targets.length,
         resourcesAdded: setup.documentsClassified + setup.documentsUnmapped,
@@ -439,12 +439,12 @@ export class KontextAgent {
 
   // ── autoSetup ───────────────────────────────────────────────
 
-  async autoSetup(targetNodeCount = 10): Promise<AutoSetupResult> {
+  async autoSetup(targetNodeCount?: number): Promise<AutoSetupResult> {
     return this.runMutation(() => this.autoSetupUnlocked(targetNodeCount));
   }
 
   private async autoSetupUnlocked(
-    targetNodeCount = 10,
+    targetNodeCount: number | undefined,
     connectors: readonly MCPConnector[] = this.mcpConnectors,
   ): Promise<AutoSetupResult> {
     const resourceInfos = await this.collectAllResources(connectors);

--- a/packages/tool-server/src/kontext-tool-server.ts
+++ b/packages/tool-server/src/kontext-tool-server.ts
@@ -116,10 +116,12 @@ export class KontextToolServer {
         targetNodeCount: z
           .number()
           .optional()
-          .describe("Target number of ontology nodes if built from scratch (default 10)"),
+          .describe(
+            "Optional target node-count override; omit to infer it from corpus size and topic diversity",
+          ),
       },
       async ({ targetNodeCount }) => {
-        const result = await this.agent.autoSetup(targetNodeCount ?? 10);
+        const result = await this.agent.autoSetup(targetNodeCount);
         const text = [
           "Auto-setup complete",
           `  Nodes created:    ${result.nodesCreated}`,

--- a/packages/tool-server/src/kontext-tool-server.ts
+++ b/packages/tool-server/src/kontext-tool-server.ts
@@ -1,3 +1,4 @@
+import { MAX_AUTO_NODE_COUNT, MIN_AUTO_NODE_COUNT } from "@kontext-brain/core";
 import type { KontextAgent } from "@kontext-brain/loader";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -115,6 +116,9 @@ export class KontextToolServer {
       {
         targetNodeCount: z
           .number()
+          .int()
+          .min(MIN_AUTO_NODE_COUNT)
+          .max(MAX_AUTO_NODE_COUNT)
           .optional()
           .describe(
             "Optional target node-count override; omit to infer it from corpus size and topic diversity",


### PR DESCRIPTION
## Summary
- infer a compact ontology node count from corpus size and extracted topic diversity when `autoSetup()` has no override
- preserve `autoSetup(8)` as an explicit advanced override and use automatic mode during initial sync/tool-server setup
- update docs and the example, and add coverage for small, diverse, large, and explicitly sized corpora

## Testing
- `corepack pnpm exec vitest run`
- `corepack pnpm exec vitest run --config bench/vitest.rag-eval-v2.config.ts`
- `corepack pnpm -r build`
- `corepack pnpm exec tsc -p bench/tsconfig.rag-eval-v2.json --noEmit`
- `corepack pnpm exec biome check packages/core/src/ingest/ontology-auto-builder.ts packages/core/tests/ontology-auto-builder.test.ts packages/loader/src/kontext-agent.ts packages/tool-server/src/kontext-tool-server.ts examples/auto-setup/src/index.ts`