### PR TITLE
fix: bind Planned Symbols against current code only

### DIFF
--- a/packages/tool-server/src/sidecar-change-evidence.ts
+++ b/packages/tool-server/src/sidecar-change-evidence.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import {
+  type CodeSymbolIdentity,
   type PlannedSymbolBinding,
   type PlannedSymbolBindingIssue,
   type PlannedSymbolRecord,
@@ -75,11 +76,12 @@ export class BoundWorkspaceChangeEvidenceProvider implements SidecarChangeEviden
         intendedIdentity: {},
         responsibility: "Legacy exact Code Symbol binding",
       }));
-    const resolution = resolvePlannedSymbols(
-      planned,
-      mergeSymbols(binding.symbolBaseline.symbols, currentSymbols.symbols),
+    const resolution = resolvePlannedSymbols(planned, currentSymbols.symbols);
+    const authorized = authorizedSymbolIds(
+      resolution.bindings,
+      binding.symbolBaseline.symbols,
+      currentSymbols.symbols,
     );
-    const authorized = new Set(resolution.bindings.map((item) => item.symbolId));
 
     return {
       currentCodeRevision: confirmedCurrent.revision,
@@ -98,15 +100,45 @@ export class BoundWorkspaceChangeEvidenceProvider implements SidecarChangeEviden
   }
 }
 
-function mergeSymbols(
-  before: readonly WorkspaceCodeSymbolState[],
-  after: readonly WorkspaceCodeSymbolState[],
-): readonly WorkspaceCodeSymbolState[] {
-  const symbols = new Map(before.map((symbol) => [symbol.symbolId, symbol] as const));
-  for (const symbol of after) symbols.set(symbol.symbolId, symbol);
-  return Array.from(symbols.values()).sort((left, right) =>
-    left.symbolId.localeCompare(right.symbolId),
+/**
+ * A Planned Symbol binds only against synchronized current code. Resolving it
+ * against the baseline as well made the pre-edit and post-edit revisions of one
+ * function two candidates sharing the same intended identity, so implementing
+ * the target symbol reported identity_ambiguous and blocked its own
+ * verification.
+ *
+ * The baseline still authorizes the predecessor that a bound symbol replaced. A
+ * behavior change gives that predecessor a different symbol ID and
+ * changedWorkspaceCodeSymbolIds reports both IDs, so the superseded one stays in
+ * scope without ever authorizing an unrelated symbol.
+ */
+function authorizedSymbolIds(
+  bindings: readonly PlannedSymbolBinding[],
+  baseline: readonly WorkspaceCodeSymbolState[],
+  current: readonly WorkspaceCodeSymbolState[],
+): ReadonlySet<string> {
+  const currentById = new Map(current.map((symbol) => [symbol.symbolId, symbol] as const));
+  const authorized = new Set(bindings.map((item) => item.symbolId));
+  const boundIdentities = new Set(
+    bindings
+      .map((item) => currentById.get(item.symbolId))
+      .filter((symbol): symbol is WorkspaceCodeSymbolState => symbol !== undefined)
+      .map((symbol) => identityKey(symbol.identity)),
   );
+  for (const symbol of baseline) {
+    if (currentById.has(symbol.symbolId)) continue;
+    if (boundIdentities.has(identityKey(symbol.identity))) authorized.add(symbol.symbolId);
+  }
+  return authorized;
+}
+
+function identityKey(identity: CodeSymbolIdentity): string {
+  return JSON.stringify([
+    identity.relativePath,
+    identity.language,
+    identity.kind,
+    identity.qualifiedName,
+  ]);
 }
 
 function sameStrings(left: readonly string[], right: readonly string[]): boolean {

--- a/packages/tool-server/tests/sidecar-change-evidence.test.ts
+++ b/packages/tool-server/tests/sidecar-change-evidence.test.ts
@@ -64,6 +64,43 @@ describe("BoundWorkspaceChangeEvidenceProvider", () => {
     expect(evidence.unauthorizedChangedSymbolIds).toEqual([]);
   });
 
+  it("binds the Planned Symbol after a throwing stub is implemented", async () => {
+    const { workspace, bindings } = await boundWorkspace(
+      "export function handler(_value: number): number {\n  throw new Error('Not implemented');\n}\n",
+    );
+    // Implementing a throw-only stub changes the inferred signature, so the
+    // symbol takes a new ID and the pre-edit and post-edit revisions used to
+    // collide as two candidates sharing one intended identity.
+    await writeFile(
+      path.join(workspace, "src/handler.ts"),
+      [
+        "export function handler(value: number) {",
+        "  if (value < 0) throw new RangeError('negative');",
+        "  return Math.min(value * 3, 4500);",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    const evidence = await new BoundWorkspaceChangeEvidenceProvider(bindings).observe({
+      workspacePath: workspace,
+      taskId,
+      workItem,
+      plannedSymbols: [plannedHandler()],
+    });
+
+    expect(evidence.plannedSymbolIssues).toEqual([]);
+    expect(evidence.plannedSymbolBindings).toEqual([
+      expect.objectContaining({
+        plannedSymbolId: "planned-symbol:handler",
+        boundBy: "intended_identity",
+      }),
+    ]);
+    // The superseded predecessor is still reported as changed, so it must not
+    // count as an out-of-scope symbol.
+    expect(evidence.unauthorizedChangedSymbolIds).toEqual([]);
+  });
+
   it("reports an unbound plan instead of accepting a caller-named symbol", async () => {
     const { workspace, bindings } = await boundWorkspace();
     await writeFile(
@@ -88,15 +125,14 @@ describe("BoundWorkspaceChangeEvidenceProvider", () => {
   });
 });
 
-async function boundWorkspace() {
+async function boundWorkspace(
+  initialSource = "export function handler(value: number) { return value + 1; }\n",
+) {
   const root = await mkdtemp(path.join(tmpdir(), "kontext-sidecar-evidence-"));
   temporaryDirectories.push(root);
   const workspace = path.join(root, "workspace");
   await mkdir(path.join(workspace, "src"), { recursive: true });
-  await writeFile(
-    path.join(workspace, "src/handler.ts"),
-    "export function handler(value: number) { return value + 1; }\n",
-  );
+  await writeFile(path.join(workspace, "src/handler.ts"), initialSource);
   execFileSync("git", ["init", "-q"], { cwd: workspace });
   execFileSync("git", ["add", "."], { cwd: workspace });
   execFileSync(


### PR DESCRIPTION
## Problem

`kontext_check_change` refused the normal Work Item edit. Reproduced end to end against the shipped plugin server: with a fully correct implementation and valid arguments it returned

```
Cannot verify unbound Planned Symbols: planned-symbol:compute-retry-delay
```

`BoundWorkspaceChangeEvidenceProvider` resolved Planned Symbols against `mergeSymbols(baseline, current)`. A behaviour-bearing Code Symbol keeps its ID across formatting and small literal edits, but implementing a `throw`-only stub changes the inferred return type from `never` to the real type, so the symbol takes a new ID. Both revisions keep the same relative path, language, kind, and qualified name, so both matched `intendedIdentity`:

```
resolve against BASELINE u CURRENT: bindings 0, identity_ambiguous
resolve against CURRENT only:       bindings 1, boundBy "intended_identity"
```

"Implement this stub" is the canonical Logic Work Item, and it is the shape the `code-quality-eval` scenario fixtures use, so the core loop refused exactly the work it was asked to verify.

## Fix

- Resolve Planned Symbols against current code only. The baseline describes code that is no longer synchronized, so it cannot supply a binding candidate.
- Authorize the predecessor that a bound symbol replaced. `changedWorkspaceCodeSymbolIds` reports both the superseded and the new ID, so without this the old ID would surface as an out-of-scope Code Symbol. Authorization is limited to a baseline symbol whose path, language, kind, and qualified name match a symbol that actually bound, so no unrelated symbol can be authorized.

## Why the suite missed it

The existing case changes `value + 1` to `value + 2`. That preserves the inferred signature and therefore the symbol ID, leaving one candidate, so it never reached the ambiguous path. The new test implements a throwing stub and fails with `identity_ambiguous` without this change.

## Validation

- `corepack pnpm -r build`
- `corepack pnpm -r typecheck`
- `vitest run`: 335 passed, 14 skipped
- `biome check` on both changed files
- New test verified red against the previous implementation and green with this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)