### PR TITLE
fix: point the Claude plugin at a recognized private data variable

### DIFF
--- a/packages/tool-server/tests/claude-plugin-bundle.test.ts
+++ b/packages/tool-server/tests/claude-plugin-bundle.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolvePluginDataDirectory } from "@kontext-brain/local";
+import { describe, expect, it } from "vitest";
+
+const pluginRoot = path.resolve(
+  fileURLToPath(new URL("../../../plugins/kontext-brain", import.meta.url)),
+);
+
+async function readJson(relativePath: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(path.join(pluginRoot, relativePath), "utf8"));
+}
+
+describe("Claude plugin bundle", () => {
+  it("declares the MCP server without an environment variable the server ignores", async () => {
+    const config = (await readJson(".claude.mcp.json")) as {
+      mcpServers: Record<string, { command: string; args: string[]; env?: Record<string, string> }>;
+    };
+    const server = config.mcpServers.kontext_brain;
+    expect(server).toBeDefined();
+    expect(server?.args).toEqual([expect.stringContaining("server.mjs")]);
+
+    // resolvePluginDataDirectory only reads these names. Declaring anything
+    // else looks like it scopes the private data directory while the server
+    // silently falls back to the shared user-level location.
+    const recognized = ["KONTEXT_PLUGIN_DATA", "PLUGIN_DATA", "CLAUDE_PLUGIN_DATA"];
+    for (const name of Object.keys(server?.env ?? {})) {
+      expect(recognized).toContain(name);
+    }
+  });
+
+  it("keeps an explicit private data directory authoritative", () => {
+    expect(
+      resolvePluginDataDirectory({ KONTEXT_PLUGIN_DATA: "/tmp/kontext-private" }, "/home/user"),
+    ).toBe(path.resolve("/tmp/kontext-private"));
+    // KONTEXT_PLUGIN_ROOT is not one of the recognized names.
+    expect(
+      resolvePluginDataDirectory(
+        { KONTEXT_PLUGIN_ROOT: "/plugins/kontext" },
+        "/home/user",
+        "linux",
+      ),
+    ).toBe(path.resolve("/home/user/.local/share/kontext-brain"));
+  });
+
+  it("publishes the repository license in both plugin manifests", async () => {
+    for (const manifest of [".claude-plugin/plugin.json", ".codex-plugin/plugin.json"]) {
+      expect((await readJson(manifest)).license).toBe("Apache-2.0");
+    }
+  });
+});

--- a/plugins/kontext-brain/.claude-plugin/plugin.json
+++ b/plugins/kontext-brain/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
     "name": "Kontext Brain"
   },
   "repository": "https://github.com/hj1105/kontext-brain-ts",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": ["code-context", "provenance", "ontology", "claude-code"],
   "skills": "./skills/",
   "hooks": "./hooks/claude-hooks.json",

--- a/plugins/kontext-brain/.claude.mcp.json
+++ b/plugins/kontext-brain/.claude.mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "kontext_brain": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/server.mjs"],
-      "env": {
-        "KONTEXT_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
-      }
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server.mjs"]
     }
   }
 }

--- a/plugins/kontext-brain/.codex-plugin/plugin.json
+++ b/plugins/kontext-brain/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Kontext Brain"
   },
   "repository": "https://github.com/hj1105/kontext-brain-ts",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": ["code-context", "provenance", "ontology", "codex"],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",


### PR DESCRIPTION
## Problem

`.claude.mcp.json` declared

```json
"env": { "KONTEXT_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}" }
```

`resolvePluginDataDirectory` only reads `KONTEXT_PLUGIN_DATA`, `PLUGIN_DATA`, or `CLAUDE_PLUGIN_DATA`, so that name is ignored. Launching the shipped `server.mjs` exactly as the Claude bundle specifies confirms it:

```
kontext-brain private data: /Users/…/.local/share/kontext-brain
```

The declaration reads like it scopes the plugin's private data directory, but the server silently falls back to the shared user-level location. The Codex bundle does this correctly by passing `KONTEXT_PLUGIN_DATA` through in `env_vars`, so only the Claude host was affected.

## Changes

- Drop the ignored variable from `.claude.mcp.json` so the server inherits the host environment on both hosts alike.
- Both plugin manifests declared `"license": "MIT"` while the repository and every package are Apache-2.0. Publish the real license.
- Add `claude-plugin-bundle.test.ts` pinning the MCP declaration to variables the resolver actually reads, and the manifests to the repository license.

## Validation

- `vitest run`: 338 passed, 14 skipped
- `biome check` on the new test
- Verified the server starts and lists all 12 tools under the Claude launch shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)