### PR TITLE
feat: measure code quality on the Codex or Claude subscription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 *.tsbuildinfo
 .turbo
 bench/data/rag-eval-v2/runs/
+bench/data/code-quality-eval/

--- a/bench/README.md
+++ b/bench/README.md
@@ -4,6 +4,37 @@ Compares 14 retrieval strategies against a vector-RAG baseline on a 12-doc
 tech-docs corpus with 8 factual queries. All systems share the same local
 Ollama models, so only the retrieval/reasoning strategy differs.
 
+## Code-quality A/B evaluation
+
+The code-quality suite measures whether Codex implements held-out, provenance-backed product
+rules more accurately when it consults Kontext Brain. Each pair uses the same model, reasoning
+effort, public task, minimal workspace, and public tests:
+
+- `baseline` runs without plugins, apps, skills, or Kontext MCP configuration.
+- `kontext` receives no policy text in its prompt and must call `kontext_prepare_task` and
+  `kontext_begin_logic` against a private sidecar fixture.
+- An evaluator outside the generated workspace scores hidden functional assertions, canonical
+  domain terms, exact-path scope, runtime completion, tokens, and duration.
+- Arm order is counterbalanced. Reports stay `inconclusive` until the release-sized threshold is
+  met, even when a small smoke run points in one direction.
+
+Build the local artifacts and run one paired repetition per scenario:
+
+```bash
+pnpm build
+pnpm --filter @kontext-brain/bench code-quality --repetitions 1
+
+# or against the Claude Code subscription
+pnpm --filter @kontext-brain/bench code-quality --runtime claude --repetitions 1
+```
+
+Pass `--runtime claude` to measure the Claude Code subscription instead; the fixture's Evidence
+egress then authorizes the `claude` provider and the private sidecar is exposed through a
+temporary `--mcp-config`. The runner removes provider API-key environment variables before
+invoking the CLI, so the measurement always uses the authenticated subscription. Generated JSON and Markdown reports
+are written under `bench/data/code-quality-eval/` and ignored by Git. Use `--output` to retain a
+dated report elsewhere.
+
 > Historical-results note: rows labeled `v1-default` below were recorded
 > before graph traversal depth and retrieval-stage order were separated.
 > The current `DEFAULT_PIPELINE` runs the full N-layer stage sequence for

--- a/bench/package.json
+++ b/bench/package.json
@@ -21,7 +21,10 @@
     "gb-llm-answer": "node --import tsx src/gb-llm-answer.ts",
     "gb-llm-judge": "node --import tsx src/gb-llm-judge.ts",
     "gb-dump-kg": "node --import tsx src/gb-dump-kg.ts",
-    "merge-claude-kg": "node --import tsx src/merge-claude-kg.ts"
+    "merge-claude-kg": "node --import tsx src/merge-claude-kg.ts",
+    "code-quality": "node --import tsx src/code-quality-eval/cli.ts",
+    "test:code-quality": "pnpm --dir .. exec vitest run --config bench/vitest.code-quality.config.ts",
+    "typecheck:code-quality": "pnpm --dir .. exec tsc -p bench/tsconfig.code-quality.json"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.120.0",

--- a/bench/src/code-quality-eval/claude-runner.test.ts
+++ b/bench/src/code-quality-eval/claude-runner.test.ts
@@ -1,0 +1,100 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import {
+  ClaudeCodeQualityRunner,
+  claudeArguments,
+  extractClaudeTools,
+  writeClaudeMcpConfig,
+} from "./claude-runner.js";
+import type { CodeQualityRunConfig } from "./contracts.js";
+import { codeQualityScenarios } from "./scenarios.js";
+
+const scenario = codeQualityScenarios[0];
+if (!scenario) throw new Error("A code-quality scenario is required");
+
+const config: CodeQualityRunConfig = {
+  runtime: "claude",
+  model: "claude-opus-5",
+  reasoningEffort: "medium",
+  repetitions: 1,
+  timeoutMilliseconds: 60_000,
+};
+
+describe("ClaudeCodeQualityRunner", () => {
+  it("grants the baseline arm no Kontext tools", () => {
+    const args = claudeArguments({ arm: "baseline", workspacePath: "/tmp/ws", config });
+    expect(args).not.toContain("--mcp-config");
+    expect(args.join(" ")).not.toContain("kontext");
+  });
+
+  it("grants the treatment arm exactly the Kontext tools plus edit primitives", () => {
+    const args = claudeArguments({
+      arm: "kontext",
+      workspacePath: "/tmp/ws",
+      config,
+      mcpConfigPath: "/tmp/mcp.json",
+    });
+    const allowed = args[args.indexOf("--allowedTools") + 1]?.split(",") ?? [];
+    expect(args).toContain("--mcp-config");
+    expect(allowed).toContain("mcp__kontext_brain__kontext_prepare_task");
+    expect(allowed).toContain("mcp__kontext_brain__kontext_begin_logic");
+    expect(allowed).toContain("mcp__kontext_brain__kontext_check_change");
+    expect(allowed).toContain("Edit");
+  });
+
+  it("refuses a treatment arm without a private MCP configuration", () => {
+    expect(() => claudeArguments({ arm: "kontext", workspacePath: "/tmp/ws", config })).toThrow(
+      /private MCP configuration/,
+    );
+  });
+
+  it("writes an MCP configuration scoped to the private data directory", async () => {
+    const configPath = await writeClaudeMcpConfig("/repo", "/tmp/private-state");
+    const written = JSON.parse(await readFile(configPath, "utf8")) as {
+      mcpServers: Record<string, { args: string[]; env: Record<string, string> }>;
+    };
+    const server = written.mcpServers.kontext_brain;
+    expect(server?.args?.[0]).toContain("plugins/kontext-brain/server.mjs");
+    // KONTEXT_PLUGIN_DATA is the name resolvePluginDataDirectory reads, so each
+    // scenario keeps its own sidecar state instead of the shared user default.
+    expect(server?.env).toEqual({ KONTEXT_PLUGIN_DATA: "/tmp/private-state" });
+  });
+
+  it("observes Kontext tool calls from stream-json events", async () => {
+    const runner = new ClaudeCodeQualityRunner(async () => ({
+      exitCode: 0,
+      stdout: [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [{ type: "tool_use", name: "mcp__kontext_brain__kontext_prepare_task" }],
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "tool_use", name: "kontext_begin_logic" }] },
+        }),
+        JSON.stringify({ type: "result", usage: { input_tokens: 900, output_tokens: 120 } }),
+      ].join("\n"),
+      stderr: "",
+      durationMilliseconds: 40,
+    }));
+    const result = await runner.execute({
+      arm: "kontext",
+      scenario,
+      workspacePath: "/tmp/ws",
+      repositoryRoot: "/repo",
+      pluginDataDirectory: "/tmp/private-state",
+      config,
+    });
+    expect(result.kontextToolsObserved).toEqual(["kontext_begin_logic", "kontext_prepare_task"]);
+    expect(result.inputTokens).toBe(900);
+    expect(result.outputTokens).toBe(120);
+  });
+
+  it("keeps an unprefixed tool name intact", () => {
+    expect(extractClaudeTools(JSON.stringify({ name: "kontext_check_change" }))).toEqual([
+      "kontext_check_change",
+    ]);
+  });
+});

--- a/bench/src/code-quality-eval/claude-runner.ts
+++ b/bench/src/code-quality-eval/claude-runner.ts
@@ -1,0 +1,205 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  type CodexCommandRunner,
+  type CodexExecutionInput,
+  type CodexExecutionResult,
+  codexPrompt,
+  codexSubscriptionEnvironment,
+  runCodexCommand,
+} from "./codex-runner.js";
+
+/**
+ * The Kontext tools are the same on both hosts, so the treatment prompt is
+ * shared. Only process invocation and event shape differ.
+ */
+export const kontextToolNames = [
+  "kontext_prepare_task",
+  "kontext_begin_logic",
+  "kontext_authorize_write",
+  "kontext_refresh_task_context",
+  "kontext_check_change",
+  "kontext_submit_change_bundle",
+  "kontext_propose_transition",
+] as const;
+
+export async function writeClaudeMcpConfig(
+  repositoryRoot: string,
+  pluginDataDirectory: string,
+): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "kontext-claude-mcp-"));
+  const configPath = path.join(directory, "mcp.json");
+  await writeFile(
+    configPath,
+    `${JSON.stringify(
+      {
+        mcpServers: {
+          kontext_brain: {
+            command: process.execPath,
+            args: [path.join(repositoryRoot, "plugins", "kontext-brain", "server.mjs")],
+            env: { KONTEXT_PLUGIN_DATA: pluginDataDirectory },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    { mode: 0o600 },
+  );
+  return configPath;
+}
+
+export function claudeArguments(input: {
+  readonly arm: CodexExecutionInput["arm"];
+  readonly workspacePath: string;
+  readonly config: CodexExecutionInput["config"];
+  readonly mcpConfigPath?: string;
+}): readonly string[] {
+  const args = [
+    "-p",
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--model",
+    input.config.model,
+    "--add-dir",
+    input.workspacePath,
+    "--max-turns",
+    "40",
+  ];
+  if (input.arm === "kontext") {
+    if (!input.mcpConfigPath) {
+      throw new Error("Kontext arm requires a private MCP configuration");
+    }
+    args.push(
+      "--mcp-config",
+      input.mcpConfigPath,
+      "--allowedTools",
+      // Only the Kontext tools plus the edit/test primitives the task needs.
+      [
+        ...kontextToolNames.map((tool) => `mcp__kontext_brain__${tool}`),
+        "Read",
+        "Edit",
+        "Write",
+        "Bash",
+      ].join(","),
+    );
+  } else {
+    args.push("--allowedTools", ["Read", "Edit", "Write", "Bash"].join(","));
+  }
+  return args;
+}
+
+/**
+ * Claude Code reports tool calls as stream-json events whose tool names carry
+ * the mcp__<server>__ prefix. extractKontextTools already strips that prefix,
+ * so the Codex extractor works unchanged.
+ */
+export class ClaudeCodeQualityRunner {
+  constructor(private readonly commandRunner: CodexCommandRunner = runCodexCommand) {}
+
+  async execute(input: CodexExecutionInput): Promise<CodexExecutionResult> {
+    const mcpConfigPath =
+      input.arm === "kontext" && input.pluginDataDirectory
+        ? await writeClaudeMcpConfig(input.repositoryRoot, input.pluginDataDirectory)
+        : undefined;
+    const result = await this.commandRunner({
+      command: "claude",
+      args: claudeArguments({
+        arm: input.arm,
+        workspacePath: input.workspacePath,
+        config: input.config,
+        ...(mcpConfigPath ? { mcpConfigPath } : {}),
+      }),
+      stdin: codexPrompt(input),
+      timeoutMilliseconds: input.config.timeoutMilliseconds,
+      environment: codexSubscriptionEnvironment(),
+    });
+    const usage = extractClaudeUsage(result.stdout);
+    return {
+      ...result,
+      ...(usage.inputTokens === undefined ? {} : { inputTokens: usage.inputTokens }),
+      ...(usage.outputTokens === undefined ? {} : { outputTokens: usage.outputTokens }),
+      kontextToolsObserved: extractClaudeTools(result.stdout),
+    };
+  }
+}
+
+export function extractClaudeTools(stdout: string): readonly string[] {
+  const tools = new Set<string>();
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      collect(JSON.parse(line) as unknown, tools);
+    } catch {
+      // Only structured stream-json events count as proof of a tool call.
+    }
+  }
+  return [...tools].sort();
+}
+
+function collect(value: unknown, tools: Set<string>): void {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) collect(item, tools);
+    return;
+  }
+  for (const [key, nested] of Object.entries(value as Readonly<Record<string, unknown>>)) {
+    if (["name", "tool", "tool_name", "toolName"].includes(key) && typeof nested === "string") {
+      const separatorIndex = nested.lastIndexOf("__");
+      const normalized = separatorIndex === -1 ? nested : nested.slice(separatorIndex + 2);
+      if (/^kontext_[a-z_]+$/.test(normalized)) tools.add(normalized);
+    }
+    collect(nested, tools);
+  }
+}
+
+export function extractClaudeUsage(stdout: string): {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+} {
+  let last: { readonly inputTokens?: number; readonly outputTokens?: number } = {};
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const usage = findUsage(JSON.parse(line) as unknown);
+      if (usage.inputTokens !== undefined || usage.outputTokens !== undefined) last = usage;
+    } catch {
+      // Claude Code may print non-JSON diagnostics alongside its event stream.
+    }
+  }
+  return last;
+}
+
+function findUsage(value: unknown): {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+} {
+  if (!value || typeof value !== "object") return {};
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const nested = findUsage(item);
+      if (nested.inputTokens !== undefined || nested.outputTokens !== undefined) return nested;
+    }
+    return {};
+  }
+  const record = value as Readonly<Record<string, unknown>>;
+  const usage = record.usage;
+  if (usage && typeof usage === "object") {
+    const fields = usage as Readonly<Record<string, unknown>>;
+    const input = fields.input_tokens ?? fields.inputTokens;
+    const output = fields.output_tokens ?? fields.outputTokens;
+    if (typeof input === "number" || typeof output === "number") {
+      return {
+        ...(typeof input === "number" ? { inputTokens: input } : {}),
+        ...(typeof output === "number" ? { outputTokens: output } : {}),
+      };
+    }
+  }
+  for (const nested of Object.values(record)) {
+    const found = findUsage(nested);
+    if (found.inputTokens !== undefined || found.outputTokens !== undefined) return found;
+  }
+  return {};
+}

--- a/bench/src/code-quality-eval/cli.ts
+++ b/bench/src/code-quality-eval/cli.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+import { access, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { CodeQualityRunConfig } from "./contracts.js";
+import { runCodeQualityEvaluation } from "./harness.js";
+import { renderCodeQualityMarkdown } from "./report.js";
+import { codeQualityScenarios } from "./scenarios.js";
+
+interface CliOptions extends CodeQualityRunConfig {
+  readonly outputPath: string;
+}
+
+async function main(): Promise<void> {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    process.stdout.write(helpText());
+    return;
+  }
+  const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+  const options = parseOptions(process.argv.slice(2), repositoryRoot);
+  await verifyBuiltArtifacts(repositoryRoot);
+  const report = await runCodeQualityEvaluation({
+    repositoryRoot,
+    scenarios: codeQualityScenarios,
+    config: options,
+    dependencies: {
+      onProgress: (message) => process.stderr.write(`${message}\n`),
+    },
+  });
+  const outputPath = path.resolve(options.outputPath);
+  const markdownPath = `${outputPath.replace(/\.json$/i, "")}.md`;
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  await writeFile(markdownPath, renderCodeQualityMarkdown(report), "utf8");
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        outputPath,
+        markdownPath,
+        verdict: report.verdict,
+        evidenceStrength: report.evidenceStrength,
+        hiddenAssertionUplift: report.hiddenAssertionUplift,
+        taskSuccessUplift: report.taskSuccessUplift,
+        paired: report.paired,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function parseOptions(args: readonly string[], repositoryRoot: string): CliOptions {
+  let runtime: CodeQualityRunConfig["runtime"] = "codex";
+  let model: string | undefined;
+  let reasoningEffort: CodeQualityRunConfig["reasoningEffort"] = "medium";
+  let repetitions = 1;
+  let timeoutMilliseconds = 300_000;
+  let outputPath = path.join(repositoryRoot, "bench", "data", "code-quality-eval", "latest.json");
+  for (let index = 0; index < args.length; index += 1) {
+    const option = args[index];
+    const value = args[index + 1];
+    if (!value) throw new Error(`Missing value for ${option}`);
+    switch (option) {
+      case "--runtime":
+        if (!isRuntime(value)) throw new Error(`Unsupported runtime: ${value}`);
+        runtime = value;
+        break;
+      case "--model":
+        model = value;
+        break;
+      case "--reasoning":
+        if (!isReasoningEffort(value)) throw new Error(`Unsupported reasoning effort: ${value}`);
+        reasoningEffort = value;
+        break;
+      case "--repetitions":
+        repetitions = positiveInteger(value, option);
+        break;
+      case "--timeout-ms":
+        timeoutMilliseconds = positiveInteger(value, option);
+        break;
+      case "--output":
+        outputPath = value;
+        break;
+      default:
+        throw new Error(`Unknown option: ${option}`);
+    }
+    index += 1;
+  }
+  return {
+    runtime,
+    model: model ?? defaultModel(runtime),
+    reasoningEffort,
+    repetitions,
+    timeoutMilliseconds,
+    outputPath,
+  };
+}
+
+function positiveInteger(value: string, option: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${option} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function isRuntime(value: string): value is CodeQualityRunConfig["runtime"] {
+  return value === "codex" || value === "claude";
+}
+
+function defaultModel(runtime: CodeQualityRunConfig["runtime"]): string {
+  return runtime === "claude" ? "claude-opus-5" : "gpt-5.6-terra";
+}
+
+function isReasoningEffort(value: string): value is CodeQualityRunConfig["reasoningEffort"] {
+  return ["low", "medium", "high", "xhigh"].includes(value);
+}
+
+async function verifyBuiltArtifacts(repositoryRoot: string): Promise<void> {
+  const required = [
+    path.join(repositoryRoot, "packages", "local", "dist", "cli.js"),
+    path.join(repositoryRoot, "plugins", "kontext-brain", "server.mjs"),
+  ];
+  try {
+    await Promise.all(required.map((artifact) => access(artifact)));
+  } catch {
+    throw new Error("Kontext artifacts are missing. Run `pnpm build` before this evaluation.");
+  }
+}
+
+function helpText(): string {
+  return `Usage: pnpm --filter @kontext-brain/bench code-quality [options]
+
+Runs paired code-generation tasks with and without Kontext Brain on the
+selected subscription runtime.
+API-key environment variables are removed so Codex uses its authenticated subscription.
+
+Options:
+  --runtime <name>        codex or claude (default: codex)
+  --model <name>          model id (default: gpt-5.6-terra, or claude-opus-5)
+  --reasoning <effort>    low, medium, high, or xhigh (default: medium)
+  --repetitions <count>   Paired repetitions per scenario (default: 1)
+  --timeout-ms <ms>       Timeout for each Codex execution (default: 300000)
+  --output <path>         JSON output path (default: bench/data/code-quality-eval/latest.json)
+  -h, --help              Show this help
+`;
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/bench/src/code-quality-eval/codex-runner.test.ts
+++ b/bench/src/code-quality-eval/codex-runner.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  CodexCodeQualityRunner,
+  codexArguments,
+  codexPrompt,
+  codexSubscriptionEnvironment,
+} from "./codex-runner.js";
+import { codeQualityScenarios } from "./scenarios.js";
+
+const scenario = codeQualityScenarios[0];
+if (!scenario) throw new Error("Expected a code-quality scenario");
+const config = {
+  runtime: "codex" as const,
+  model: "test-model",
+  reasoningEffort: "medium" as const,
+  repetitions: 1,
+  timeoutMilliseconds: 1_000,
+};
+
+describe("CodexCodeQualityRunner", () => {
+  it("keeps the baseline free of Kontext configuration and private policy", () => {
+    const input = {
+      arm: "baseline" as const,
+      scenario,
+      workspacePath: "/tmp/workspace",
+      repositoryRoot: "/repo",
+      config,
+    };
+    expect(codexArguments(input).join(" ")).not.toContain("mcp_servers.kontext_brain");
+    const prompt = codexPrompt(input);
+    expect(prompt).not.toContain("kontext_prepare_task");
+    for (const rule of scenario.rules) {
+      expect(prompt).not.toContain(rule.evidenceText);
+      if (rule.statement) expect(prompt).not.toContain(rule.statement);
+      if (rule.definition) expect(prompt).not.toContain(rule.definition);
+    }
+  });
+
+  it("configures only the treatment MCP and does not leak normative content", () => {
+    const input = {
+      arm: "kontext" as const,
+      scenario,
+      workspacePath: "/tmp/workspace",
+      repositoryRoot: "/repo",
+      pluginDataDirectory: "/tmp/plugin-data",
+      config,
+    };
+    expect(codexArguments(input).join(" ")).toContain("mcp_servers.kontext_brain");
+    const prompt = codexPrompt(input);
+    expect(prompt).toContain("kontext_prepare_task");
+    expect(prompt).toContain(scenario.taskId);
+    for (const rule of scenario.rules) {
+      expect(prompt).not.toContain(rule.evidenceText);
+      if (rule.statement) expect(prompt).not.toContain(rule.statement);
+      if (rule.definition) expect(prompt).not.toContain(rule.definition);
+    }
+  });
+
+  it("removes usage-billed provider keys while retaining subscription auth state", () => {
+    const environment = codexSubscriptionEnvironment({
+      OPENAI_API_KEY: "remove",
+      ANTHROPIC_API_KEY: "remove",
+      CODEX_HOME: "/subscription-state",
+      PATH: "/bin",
+    });
+    expect(environment.OPENAI_API_KEY).toBeUndefined();
+    expect(environment.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(environment.CODEX_HOME).toBe("/subscription-state");
+    expect(environment.PATH).toBe("/bin");
+  });
+
+  it("extracts usage and observed Kontext tool calls from Codex JSONL", async () => {
+    const runner = new CodexCodeQualityRunner(async () => ({
+      exitCode: 0,
+      stdout: [
+        JSON.stringify({ item: { name: "mcp__kontext_brain__kontext_prepare_task" } }),
+        JSON.stringify({ item: { name: "kontext_begin_logic" } }),
+        JSON.stringify({ usage: { input_tokens: 120, output_tokens: 30 } }),
+      ].join("\n"),
+      stderr: "",
+      durationMilliseconds: 25,
+    }));
+    const result = await runner.execute({
+      arm: "kontext",
+      scenario,
+      workspacePath: "/tmp/workspace",
+      repositoryRoot: "/repo",
+      pluginDataDirectory: "/tmp/plugin-data",
+      config,
+    });
+    expect(result.inputTokens).toBe(120);
+    expect(result.outputTokens).toBe(30);
+    expect(result.kontextToolsObserved).toEqual(["kontext_begin_logic", "kontext_prepare_task"]);
+  });
+});

--- a/bench/src/code-quality-eval/codex-runner.ts
+++ b/bench/src/code-quality-eval/codex-runner.ts
@@ -1,0 +1,316 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import type { CodeQualityArm, CodeQualityRunConfig, CodeQualityScenario } from "./contracts.js";
+
+const providerApiKeyEnvironmentVariables = [
+  "OPENAI_API_KEY",
+  "CODEX_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "AZURE_OPENAI_API_KEY",
+  "NVIDIA_API_KEY",
+] as const;
+
+export interface CodexExecutionInput {
+  readonly arm: CodeQualityArm;
+  readonly scenario: CodeQualityScenario;
+  readonly workspacePath: string;
+  readonly repositoryRoot: string;
+  readonly pluginDataDirectory?: string;
+  readonly config: CodeQualityRunConfig;
+}
+
+export interface CodexExecutionResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly durationMilliseconds: number;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly kontextToolsObserved: readonly string[];
+}
+
+export type CodexCommandRunner = (input: {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly stdin: string;
+  readonly timeoutMilliseconds: number;
+  readonly environment: NodeJS.ProcessEnv;
+}) => Promise<{
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly durationMilliseconds: number;
+}>;
+
+export class CodexCodeQualityRunner {
+  constructor(private readonly commandRunner: CodexCommandRunner = runCodexCommand) {}
+
+  async execute(input: CodexExecutionInput): Promise<CodexExecutionResult> {
+    const result = await this.commandRunner({
+      command: "codex",
+      args: codexArguments(input),
+      stdin: codexPrompt(input),
+      timeoutMilliseconds: input.config.timeoutMilliseconds,
+      environment: codexSubscriptionEnvironment(),
+    });
+    const usage = extractLastUsage(result.stdout);
+    return {
+      ...result,
+      ...(usage.inputTokens === undefined ? {} : { inputTokens: usage.inputTokens }),
+      ...(usage.outputTokens === undefined ? {} : { outputTokens: usage.outputTokens }),
+      kontextToolsObserved: extractKontextTools(result.stdout),
+    };
+  }
+}
+
+export function codexSubscriptionEnvironment(
+  baseEnvironment: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const environment = { ...baseEnvironment };
+  for (const name of providerApiKeyEnvironmentVariables) delete environment[name];
+  return environment;
+}
+
+export function codexArguments(input: CodexExecutionInput): readonly string[] {
+  const args = [
+    "exec",
+    "--ephemeral",
+    "--ignore-user-config",
+    "--ignore-rules",
+    "--disable",
+    "plugins",
+    "--disable",
+    "remote_plugin",
+    "--disable",
+    "plugin_sharing",
+    "--disable",
+    "apps",
+    "--disable",
+    "browser_use",
+    "--disable",
+    "browser_use_external",
+    "--disable",
+    "browser_use_full_cdp_access",
+    "--disable",
+    "in_app_browser",
+    "--disable",
+    "skill_mcp_dependency_install",
+    "--skip-git-repo-check",
+    "--sandbox",
+    "workspace-write",
+    "--json",
+    "--model",
+    input.config.model,
+    "--config",
+    `model_reasoning_effort=${JSON.stringify(input.config.reasoningEffort)}`,
+  ];
+  if (input.arm === "kontext") {
+    if (!input.pluginDataDirectory) {
+      throw new Error("Kontext arm requires a private plugin data directory");
+    }
+    const pluginDirectory = path.join(input.repositoryRoot, "plugins", "kontext-brain");
+    args.push(
+      "--config",
+      `mcp_servers.kontext_brain.command=${JSON.stringify(process.execPath)}`,
+      "--config",
+      `mcp_servers.kontext_brain.args=[${JSON.stringify(path.join(pluginDirectory, "server.mjs"))}]`,
+      "--config",
+      `mcp_servers.kontext_brain.cwd=${JSON.stringify(pluginDirectory)}`,
+      "--config",
+      `mcp_servers.kontext_brain.env={KONTEXT_PLUGIN_DATA=${JSON.stringify(input.pluginDataDirectory)}}`,
+    );
+  }
+  args.push("--cd", input.workspacePath, "-");
+  return args;
+}
+
+export function codexPrompt(input: CodexExecutionInput): string {
+  const shared = [
+    "Complete this coding task autonomously.",
+    input.scenario.publicPrompt,
+    `Work only inside ${input.workspacePath}.`,
+    `Edit only ${input.scenario.sourceFile}; do not create or change any other file.`,
+    "Do not inspect files outside this workspace for implementation guidance.",
+    "Run npm test before finishing. Do not ask questions.",
+  ];
+  if (input.arm === "baseline") return `${shared.join("\n")}\n`;
+
+  const contract = {
+    taskId: input.scenario.taskId,
+    intent: input.scenario.intent,
+    acceptance: [
+      {
+        criterionId: `criterion:${input.scenario.scenarioId}:policy`,
+        statement: "The target function implements the current approved product policy.",
+        verifier: { kind: "test", ref: "workspace:test" },
+      },
+    ],
+    nonGoals: ["Changing the public API", "Editing files outside the target source file"],
+    targets: [input.scenario.plannedSymbolId],
+    risk: "low",
+  } as const;
+  const begin = {
+    taskId: input.scenario.taskId,
+    workspacePath: input.workspacePath,
+    logic: {
+      workItemId: input.scenario.workItemId,
+      plannedSymbolIds: [input.scenario.plannedSymbolId],
+    },
+    runtimeProvider: "codex",
+    receiptTtlSeconds: 900,
+    totalTokenBudget: 8_000,
+    optionalEvidenceTokenBudget: 2_000,
+  } as const;
+
+  return `${shared.join("\n")}
+
+The kontext_brain MCP server is the only source of the private current policy. Follow this workflow:
+1. Call kontext_prepare_task with contract=${JSON.stringify(contract)} and a current ISO createdAt.
+2. Call kontext_begin_logic with ${JSON.stringify(begin)}.
+3. Continue only if editingAllowed is true. Treat returned mandatory Decisions, Domain Terms, and Invariants as authoritative; use Evidence only as provenance.
+4. Implement exactly within the receipt's allowed path and use the returned canonical domain language.
+5. After the edit, call kontext_check_change for the fast tier and then the targeted tier, using the exact Task ID, Work Item ID, workspace path, a current ISO observedAt, and an ISO nextAttemptAt slightly in the future.
+Do not substitute your own policy when Kontext context is available.
+`;
+}
+
+export function extractKontextTools(stdout: string): readonly string[] {
+  const tools = new Set<string>();
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      collectToolNames(JSON.parse(line) as unknown, tools);
+    } catch {
+      // Only structured Codex events count as proof that an MCP tool was called.
+    }
+  }
+  return [...tools].sort();
+}
+
+function collectToolNames(value: unknown, tools: Set<string>): void {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) collectToolNames(item, tools);
+    return;
+  }
+  for (const [key, nested] of Object.entries(value as Readonly<Record<string, unknown>>)) {
+    if (["name", "tool", "tool_name", "toolName"].includes(key) && typeof nested === "string") {
+      const separatorIndex = nested.lastIndexOf("__");
+      const normalized = separatorIndex === -1 ? nested : nested.slice(separatorIndex + 2);
+      if (/^kontext_[a-z_]+$/.test(normalized)) tools.add(normalized);
+    }
+    collectToolNames(nested, tools);
+  }
+}
+
+function extractLastUsage(stdout: string): {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+} {
+  let last: { readonly inputTokens?: number; readonly outputTokens?: number } = {};
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const usage = findUsage(JSON.parse(line) as unknown);
+      if (usage.inputTokens !== undefined || usage.outputTokens !== undefined) last = usage;
+    } catch {
+      // Codex may emit non-JSON diagnostics next to its JSONL event stream.
+    }
+  }
+  return last;
+}
+
+function findUsage(value: unknown): {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+} {
+  if (!value || typeof value !== "object") return {};
+  const object = value as Readonly<Record<string, unknown>>;
+  const inputTokens = numericField(object, ["input_tokens", "inputTokens"]);
+  const outputTokens = numericField(object, ["output_tokens", "outputTokens"]);
+  if (inputTokens !== undefined || outputTokens !== undefined) {
+    return {
+      ...(inputTokens === undefined ? {} : { inputTokens }),
+      ...(outputTokens === undefined ? {} : { outputTokens }),
+    };
+  }
+  for (const nested of Object.values(object)) {
+    const usage = findUsage(nested);
+    if (usage.inputTokens !== undefined || usage.outputTokens !== undefined) return usage;
+  }
+  return {};
+}
+
+function numericField(
+  object: Readonly<Record<string, unknown>>,
+  fields: readonly string[],
+): number | undefined {
+  for (const field of fields) {
+    const value = object[field];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+export async function runCodexCommand(input: {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly stdin: string;
+  readonly timeoutMilliseconds: number;
+  readonly environment: NodeJS.ProcessEnv;
+}): Promise<{
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly durationMilliseconds: number;
+}> {
+  const startedAt = performance.now();
+  return await new Promise((resolve, reject) => {
+    const child = spawn(input.command, [...input.args], {
+      env: input.environment,
+      shell: false,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+    let forceKillTimer: NodeJS.Timeout | undefined;
+    const settle = (operation: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutTimer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      operation();
+    };
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      forceKillTimer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+    }, input.timeoutMilliseconds);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => settle(() => reject(error)));
+    child.on("close", (code) =>
+      settle(() =>
+        resolve({
+          exitCode: timedOut ? 124 : (code ?? 1),
+          stdout,
+          stderr: timedOut
+            ? `${stderr}\nTimed out after ${input.timeoutMilliseconds}ms`.trim()
+            : stderr,
+          durationMilliseconds: performance.now() - startedAt,
+        }),
+      ),
+    );
+    child.stdin.end(input.stdin);
+  });
+}

--- a/bench/src/code-quality-eval/contracts.ts
+++ b/bench/src/code-quality-eval/contracts.ts
@@ -1,0 +1,116 @@
+export type CodeQualityArm = "baseline" | "kontext";
+
+export interface CodeQualityNormativeRule {
+  readonly kind: "decision" | "domain_term" | "invariant";
+  readonly recordId: string;
+  readonly revisionId: string;
+  readonly statement?: string;
+  readonly term?: string;
+  readonly definition?: string;
+  readonly avoid?: readonly string[];
+  readonly evidenceId: string;
+  readonly evidenceText: string;
+}
+
+export interface HiddenAssertionResult {
+  readonly assertionId: string;
+  readonly passed: boolean;
+  readonly diagnostic?: string;
+}
+
+export interface HiddenEvaluationResult {
+  readonly assertions: readonly HiddenAssertionResult[];
+}
+
+export interface CodeQualityScenario {
+  readonly scenarioId: string;
+  readonly taskId: string;
+  readonly intent: string;
+  readonly publicPrompt: string;
+  readonly sourceFile: string;
+  readonly initialSource: string;
+  readonly publicTestSource: string;
+  readonly workItemId: string;
+  readonly plannedSymbolId: string;
+  readonly qualifiedName: string;
+  readonly capabilityId: string;
+  readonly canonicalTerms: readonly string[];
+  readonly rules: readonly CodeQualityNormativeRule[];
+  evaluateHidden(module: Readonly<Record<string, unknown>>): Promise<HiddenEvaluationResult>;
+}
+
+export type CodeQualityRuntime = "codex" | "claude";
+
+export interface CodeQualityRunConfig {
+  readonly runtime: CodeQualityRuntime;
+  readonly model: string;
+  readonly reasoningEffort: "low" | "medium" | "high" | "xhigh";
+  readonly repetitions: number;
+  readonly timeoutMilliseconds: number;
+}
+
+export interface CodeQualityRunResult {
+  readonly runId: string;
+  readonly scenarioId: string;
+  readonly repetition: number;
+  readonly arm: CodeQualityArm;
+  readonly model: string;
+  readonly reasoningEffort: CodeQualityRunConfig["reasoningEffort"];
+  readonly startedAt: string;
+  readonly finishedAt: string;
+  readonly durationMilliseconds: number;
+  readonly runtimeExitCode: number;
+  readonly runtimeDiagnostic?: string;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly publicTestsPassed: boolean;
+  readonly hiddenAssertions: readonly HiddenAssertionResult[];
+  readonly canonicalTermsPresent: readonly string[];
+  readonly canonicalTermsMissing: readonly string[];
+  readonly changedPaths: readonly string[];
+  readonly outOfScopePaths: readonly string[];
+  readonly kontextToolsObserved: readonly string[];
+  readonly contextConsulted: boolean;
+  readonly evaluationEligible: boolean;
+  readonly source: string;
+  readonly patch: string;
+}
+
+export interface ArmSummary {
+  readonly arm: CodeQualityArm;
+  readonly runs: number;
+  readonly eligibleRuns: number;
+  readonly runtimeCompletionRate: number;
+  readonly publicTestPassRate: number;
+  readonly hiddenAssertionPassRate: number;
+  readonly taskSuccessRate: number;
+  readonly canonicalTermPassRate: number;
+  readonly scopeComplianceRate: number;
+  readonly contextConsultationRate?: number;
+  readonly meanDurationMilliseconds: number;
+  readonly meanInputTokens?: number;
+  readonly meanOutputTokens?: number;
+}
+
+export interface PairedOutcomeSummary {
+  readonly pairs: number;
+  readonly kontextWins: number;
+  readonly baselineWins: number;
+  readonly ties: number;
+  readonly twoSidedSignTestPValue?: number;
+}
+
+export interface CodeQualityReport {
+  readonly schemaVersion: 1;
+  readonly generatedAt: string;
+  readonly config: CodeQualityRunConfig;
+  readonly scenarios: readonly string[];
+  readonly runs: readonly CodeQualityRunResult[];
+  readonly summaries: readonly ArmSummary[];
+  readonly paired: PairedOutcomeSummary;
+  readonly hiddenAssertionUplift: number;
+  readonly taskSuccessUplift: number;
+  readonly evidenceStrength: "smoke" | "pilot" | "release";
+  readonly verdict: "improvement" | "regression" | "no_detected_difference" | "inconclusive";
+  readonly limitations: readonly string[];
+}

--- a/bench/src/code-quality-eval/harness.test.ts
+++ b/bench/src/code-quality-eval/harness.test.ts
@@ -1,0 +1,84 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCodeQualityEvaluation } from "./harness.js";
+import { codeQualityScenarios } from "./scenarios.js";
+
+const correctSources: Readonly<Record<string, string>> = {
+  "retry-policy": `const RECOVERY_WINDOW_MS = 4500;
+export function computeRetryDelay(failureIndex, baseMs) {
+  if (!Number.isInteger(failureIndex) || failureIndex < 0 || !Number.isInteger(baseMs) || baseMs < 0) throw new RangeError("invalid input");
+  return Math.min(baseMs * 3 ** failureIndex, RECOVERY_WINDOW_MS);
+}
+`,
+  "order-cancellation": `export function cancellationOutcome(order) {
+  const hasRevocationEligibility = order.state === "confirmed" && !order.shipmentId && order.fraudHold !== true;
+  return hasRevocationEligibility ? "revocable" : "locked";
+}
+`,
+  "service-credit-allocation": `export function allocateServiceCredit(totalCents, accountIds) {
+  if (!Number.isInteger(totalCents) || totalCents < 0) throw new RangeError("invalid total");
+  if (accountIds.length === 0 || accountIds.some((id) => !id) || new Set(accountIds).size !== accountIds.length) throw new Error("invalid accounts");
+  const sorted = [...accountIds].sort();
+  const base = Math.floor(totalCents / sorted.length);
+  const remainder = totalCents % sorted.length;
+  const serviceCreditByAccount = {};
+  for (const [index, id] of sorted.entries()) serviceCreditByAccount[id] = base + (index >= sorted.length - remainder ? 1 : 0);
+  return serviceCreditByAccount;
+}
+`,
+};
+
+const baselineSources: Readonly<Record<string, string>> = {
+  "retry-policy": "export function computeRetryDelay(_failureIndex, baseMs) { return baseMs; }\n",
+  "order-cancellation": 'export function cancellationOutcome() { return "revocable"; }\n',
+  "service-credit-allocation": `export function allocateServiceCredit(totalCents, accountIds) {
+  const each = totalCents / accountIds.length;
+  return Object.fromEntries([...accountIds].sort().map((id) => [id, each]));
+}\n`,
+};
+
+describe("code-quality harness", () => {
+  it("runs paired isolated workspaces and scores held-out requirements", async () => {
+    let publishedStates = 0;
+    const report = await runCodeQualityEvaluation({
+      repositoryRoot: "/repo",
+      scenarios: codeQualityScenarios,
+      config: {
+        runtime: "codex",
+        model: "fixture-model",
+        reasoningEffort: "medium",
+        repetitions: 1,
+        timeoutMilliseconds: 1_000,
+      },
+      dependencies: {
+        publishState: async () => {
+          publishedStates += 1;
+        },
+        execute: async (input) => {
+          const sources = input.arm === "kontext" ? correctSources : baselineSources;
+          const source = sources[input.scenario.scenarioId];
+          if (!source) throw new Error(`Missing source for ${input.scenario.scenarioId}`);
+          await writeFile(path.join(input.workspacePath, input.scenario.sourceFile), source);
+          return {
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+            durationMilliseconds: 10,
+            kontextToolsObserved:
+              input.arm === "kontext" ? ["kontext_prepare_task", "kontext_begin_logic"] : [],
+          };
+        },
+      },
+    });
+
+    expect(publishedStates).toBe(codeQualityScenarios.length);
+    expect(report.runs).toHaveLength(codeQualityScenarios.length * 2);
+    expect(report.hiddenAssertionUplift).toBeGreaterThan(0);
+    expect(report.paired.kontextWins).toBe(codeQualityScenarios.length);
+    expect(report.summaries.find((summary) => summary.arm === "kontext")).toMatchObject({
+      contextConsultationRate: 1,
+      taskSuccessRate: 1,
+    });
+  });
+});

--- a/bench/src/code-quality-eval/harness.ts
+++ b/bench/src/code-quality-eval/harness.ts
@@ -1,0 +1,176 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ClaudeCodeQualityRunner } from "./claude-runner.js";
+import {
+  CodexCodeQualityRunner,
+  type CodexExecutionInput,
+  type CodexExecutionResult,
+} from "./codex-runner.js";
+import type {
+  CodeQualityArm,
+  CodeQualityReport,
+  CodeQualityRunConfig,
+  CodeQualityRunResult,
+  CodeQualityScenario,
+} from "./contracts.js";
+import { publishScenarioState } from "./kontext-state.js";
+import { buildCodeQualityReport } from "./report.js";
+import { createScenarioWorkspace, evaluateWorkspace } from "./workspace.js";
+
+export interface CodeQualityHarnessDependencies {
+  readonly execute?: (input: CodexExecutionInput) => Promise<CodexExecutionResult>;
+  readonly publishState?: typeof publishScenarioState;
+  readonly onProgress?: (message: string) => void;
+}
+
+export async function runCodeQualityEvaluation(input: {
+  readonly repositoryRoot: string;
+  readonly scenarios: readonly CodeQualityScenario[];
+  readonly config: CodeQualityRunConfig;
+  readonly dependencies?: CodeQualityHarnessDependencies;
+}): Promise<CodeQualityReport> {
+  const runner =
+    input.config.runtime === "claude"
+      ? new ClaudeCodeQualityRunner()
+      : new CodexCodeQualityRunner();
+  const execute = input.dependencies?.execute ?? ((execution) => runner.execute(execution));
+  const publishState = input.dependencies?.publishState ?? publishScenarioState;
+  const progress = input.dependencies?.onProgress ?? (() => undefined);
+  const runs: CodeQualityRunResult[] = [];
+
+  for (let repetition = 1; repetition <= input.config.repetitions; repetition += 1) {
+    for (const [scenarioIndex, scenario] of input.scenarios.entries()) {
+      const arms: readonly CodeQualityArm[] =
+        (scenarioIndex + repetition) % 2 === 0 ? ["baseline", "kontext"] : ["kontext", "baseline"];
+      for (const arm of arms) {
+        progress(`[${scenario.scenarioId} r${repetition}] ${arm} starting`);
+        const run = await runArm({
+          repositoryRoot: input.repositoryRoot,
+          scenario,
+          repetition,
+          arm,
+          config: input.config,
+          execute,
+          publishState,
+        });
+        runs.push(run);
+        const passed = run.hiddenAssertions.filter((assertion) => assertion.passed).length;
+        progress(
+          `[${scenario.scenarioId} r${repetition}] ${arm} finished: hidden ${passed}/${run.hiddenAssertions.length}, public ${run.publicTestsPassed ? "pass" : "fail"}`,
+        );
+      }
+    }
+  }
+
+  return buildCodeQualityReport({
+    config: input.config,
+    scenarios: input.scenarios.map((scenario) => scenario.scenarioId),
+    runs,
+  });
+}
+
+async function runArm(input: {
+  readonly repositoryRoot: string;
+  readonly scenario: CodeQualityScenario;
+  readonly repetition: number;
+  readonly arm: CodeQualityArm;
+  readonly config: CodeQualityRunConfig;
+  readonly execute: (input: CodexExecutionInput) => Promise<CodexExecutionResult>;
+  readonly publishState: typeof publishScenarioState;
+}): Promise<CodeQualityRunResult> {
+  const workspace = await createScenarioWorkspace(input.scenario);
+  const pluginDataDirectory = await mkdtemp(
+    path.join(tmpdir(), `kontext-code-eval-state-${input.scenario.scenarioId}-`),
+  );
+  const startedAt = new Date();
+  let execution: CodexExecutionResult;
+  try {
+    if (input.arm === "kontext") {
+      await input.publishState({
+        scenario: input.scenario,
+        baseRevision: workspace.baseRevision,
+        repositoryRoot: input.repositoryRoot,
+        pluginDataDirectory,
+        runtime: input.config.runtime,
+      });
+    }
+    execution = await input.execute({
+      arm: input.arm,
+      scenario: input.scenario,
+      workspacePath: workspace.workspacePath,
+      repositoryRoot: input.repositoryRoot,
+      ...(input.arm === "kontext" ? { pluginDataDirectory } : {}),
+      config: input.config,
+    });
+  } catch (error) {
+    execution = {
+      exitCode: 1,
+      stdout: "",
+      stderr: errorMessage(error),
+      durationMilliseconds: Date.now() - startedAt.getTime(),
+      kontextToolsObserved: [],
+    };
+  }
+
+  try {
+    const evaluation = await evaluateWorkspace(input.scenario, workspace.workspacePath);
+    const canonicalTermsPresent = input.scenario.canonicalTerms.filter((term) =>
+      evaluation.source.includes(term),
+    );
+    const canonicalTermsMissing = input.scenario.canonicalTerms.filter(
+      (term) => !canonicalTermsPresent.includes(term),
+    );
+    const outOfScopePaths = evaluation.changedPaths.filter(
+      (changedPath) => changedPath !== input.scenario.sourceFile,
+    );
+    const contextConsulted =
+      input.arm === "kontext" &&
+      execution.kontextToolsObserved.includes("kontext_prepare_task") &&
+      execution.kontextToolsObserved.includes("kontext_begin_logic");
+    const evaluationEligible =
+      execution.exitCode === 0 && (input.arm === "baseline" || contextConsulted);
+    const finishedAt = new Date();
+    const diagnostic = [
+      execution.stderr.trim(),
+      ...(evaluationEligible ? [] : [execution.stdout.trim()]),
+    ]
+      .filter(Boolean)
+      .join("\n");
+    return {
+      runId: `${input.scenario.scenarioId}:r${input.repetition}:${input.arm}`,
+      scenarioId: input.scenario.scenarioId,
+      repetition: input.repetition,
+      arm: input.arm,
+      model: input.config.model,
+      reasoningEffort: input.config.reasoningEffort,
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      durationMilliseconds: execution.durationMilliseconds,
+      runtimeExitCode: execution.exitCode,
+      ...(diagnostic ? { runtimeDiagnostic: diagnostic.slice(-12_000) } : {}),
+      ...(execution.inputTokens === undefined ? {} : { inputTokens: execution.inputTokens }),
+      ...(execution.outputTokens === undefined ? {} : { outputTokens: execution.outputTokens }),
+      publicTestsPassed: evaluation.publicTestsPassed,
+      hiddenAssertions: evaluation.hidden.assertions,
+      canonicalTermsPresent,
+      canonicalTermsMissing,
+      changedPaths: evaluation.changedPaths,
+      outOfScopePaths,
+      kontextToolsObserved: execution.kontextToolsObserved,
+      contextConsulted,
+      evaluationEligible,
+      source: evaluation.source,
+      patch: evaluation.patch,
+    };
+  } finally {
+    await Promise.all([
+      rm(workspace.workspacePath, { recursive: true, force: true }),
+      rm(pluginDataDirectory, { recursive: true, force: true }),
+    ]);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}

--- a/bench/src/code-quality-eval/kontext-state.ts
+++ b/bench/src/code-quality-eval/kontext-state.ts
@@ -1,0 +1,140 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  CodeQualityNormativeRule,
+  CodeQualityRuntime,
+  CodeQualityScenario,
+} from "./contracts.js";
+import { runWorkspaceCommand } from "./workspace.js";
+
+const organizationId = "personal:code-quality-eval";
+const scope = { kind: "workspace", workspaceId: "workspace:code-quality-eval" } as const;
+
+export async function publishScenarioState(input: {
+  readonly scenario: CodeQualityScenario;
+  readonly baseRevision: string;
+  readonly repositoryRoot: string;
+  readonly pluginDataDirectory: string;
+  readonly runtime?: CodeQualityRuntime;
+}): Promise<void> {
+  const runtime = input.runtime ?? "codex";
+  await mkdir(input.pluginDataDirectory, { recursive: true, mode: 0o700 });
+  const assemblyPath = path.join(input.pluginDataDirectory, "assembly.json");
+  await writeFile(
+    assemblyPath,
+    `${JSON.stringify(assembly(input.scenario, input.baseRevision, runtime), null, 2)}\n`,
+    { mode: 0o600 },
+  );
+  const cliPath = path.join(input.repositoryRoot, "packages", "local", "dist", "cli.js");
+  const result = await runWorkspaceCommand(
+    input.repositoryRoot,
+    process.execPath,
+    [cliPath, "publish-task-state", assemblyPath],
+    { ...process.env, KONTEXT_PLUGIN_DATA: input.pluginDataDirectory },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`Cannot publish Kontext state: ${result.stderr || result.stdout}`);
+  }
+}
+
+function assembly(
+  scenario: CodeQualityScenario,
+  baseRevision: string,
+  runtime: CodeQualityRuntime,
+): unknown {
+  const authoredAt = "2026-08-31T00:00:00.000Z";
+  const acceptedAt = "2026-08-31T00:01:00.000Z";
+  return {
+    taskId: scenario.taskId,
+    organizationId,
+    codeRevision: baseRevision,
+    baseScopes: [scope],
+    localManifest: {
+      schemaVersion: 1,
+      organizationId,
+      revisions: scenario.rules.map((rule) => revision(rule, authoredAt, runtime)),
+      activations: scenario.rules.map((rule) => ({
+        organizationId,
+        kind: rule.kind,
+        recordId: rule.recordId,
+        revisionId: rule.revisionId,
+        scope,
+        state: "accepted_local",
+        acceptedBy: "user:code-quality-eval",
+        acceptedAt,
+      })),
+    },
+    evidence: scenario.rules.map((rule) => ({
+      evidenceId: rule.evidenceId,
+      text: rule.evidenceText,
+      sourceSpan: `held-out policy fixture:${scenario.scenarioId}`,
+      availability: "current",
+      allowedRuntimeProviders: [runtime],
+    })),
+    logicPlans: [
+      {
+        workItemId: scenario.workItemId,
+        plannedSymbolIds: [scenario.plannedSymbolId],
+        plannedSymbols: [
+          {
+            plannedSymbolId: scenario.plannedSymbolId,
+            taskId: scenario.taskId,
+            intendedIdentity: {
+              relativePath: scenario.sourceFile,
+              language: languageForPath(scenario.sourceFile),
+              kind: "function",
+              qualifiedName: scenario.qualifiedName,
+            },
+            responsibility: scenario.intent,
+          },
+        ],
+        allowedPaths: [scenario.sourceFile],
+        dependsOn: [],
+        requiredVerifiers: [{ kind: "test", ref: "workspace:test" }],
+        capabilityId: scenario.capabilityId,
+      },
+    ],
+  };
+}
+
+function languageForPath(filePath: string): "typescript" | "javascript" {
+  return /\.[cm]?jsx?$/i.test(filePath) ? "javascript" : "typescript";
+}
+
+function revision(
+  rule: CodeQualityNormativeRule,
+  authoredAt: string,
+  runtime: CodeQualityRuntime,
+): unknown {
+  const common = {
+    kind: rule.kind,
+    organizationId,
+    recordId: rule.recordId,
+    revisionId: rule.revisionId,
+    scope,
+    evidence: [{ evidenceId: rule.evidenceId, sourceSpan: "held-out policy fixture" }],
+    egress: {
+      dataClassification: "internal",
+      allowedRuntimeProviders: [runtime],
+    },
+    authoredBy: "user:code-quality-eval",
+    authoredAt,
+  };
+  switch (rule.kind) {
+    case "decision":
+      return { ...common, statement: rule.statement };
+    case "domain_term":
+      return {
+        ...common,
+        term: rule.term,
+        definition: rule.definition,
+        avoid: rule.avoid,
+      };
+    case "invariant":
+      return {
+        ...common,
+        statement: rule.statement,
+        verifiers: [{ kind: "test", ref: "workspace:test" }],
+      };
+  }
+}

--- a/bench/src/code-quality-eval/report.test.ts
+++ b/bench/src/code-quality-eval/report.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { CodeQualityArm, CodeQualityRunResult } from "./contracts.js";
+import { buildCodeQualityReport, exactTwoSidedSignTest } from "./report.js";
+
+describe("code-quality report", () => {
+  it("computes paired wins and keeps smoke evidence inconclusive", () => {
+    const report = buildCodeQualityReport({
+      generatedAt: "2026-08-31T00:00:00.000Z",
+      config: {
+        runtime: "codex",
+        model: "test-model",
+        reasoningEffort: "medium",
+        repetitions: 1,
+        timeoutMilliseconds: 1_000,
+      },
+      scenarios: ["scenario:a"],
+      runs: [run("baseline", false), run("kontext", true)],
+    });
+    expect(report.hiddenAssertionUplift).toBe(1);
+    expect(report.taskSuccessUplift).toBe(1);
+    expect(report.paired).toMatchObject({ pairs: 1, kontextWins: 1, baselineWins: 0 });
+    expect(report.evidenceStrength).toBe("smoke");
+    expect(report.verdict).toBe("inconclusive");
+  });
+
+  it("computes the exact two-sided sign-test probability", () => {
+    expect(exactTwoSidedSignTest(5, 0)).toBeCloseTo(0.0625);
+    expect(exactTwoSidedSignTest(3, 2)).toBe(1);
+  });
+});
+
+function run(arm: CodeQualityArm, passed: boolean): CodeQualityRunResult {
+  return {
+    runId: `scenario:a:r1:${arm}`,
+    scenarioId: "scenario:a",
+    repetition: 1,
+    arm,
+    model: "test-model",
+    reasoningEffort: "medium",
+    startedAt: "2026-08-31T00:00:00.000Z",
+    finishedAt: "2026-08-31T00:00:01.000Z",
+    durationMilliseconds: 1_000,
+    runtimeExitCode: 0,
+    publicTestsPassed: true,
+    hiddenAssertions: [{ assertionId: "policy", passed }],
+    canonicalTermsPresent: passed ? ["canonicalName"] : [],
+    canonicalTermsMissing: passed ? [] : ["canonicalName"],
+    changedPaths: ["src/policy.js"],
+    outOfScopePaths: [],
+    kontextToolsObserved: arm === "kontext" ? ["kontext_prepare_task", "kontext_begin_logic"] : [],
+    contextConsulted: arm === "kontext",
+    evaluationEligible: true,
+    source: "",
+    patch: "",
+  };
+}

--- a/bench/src/code-quality-eval/report.ts
+++ b/bench/src/code-quality-eval/report.ts
@@ -1,0 +1,270 @@
+import type {
+  ArmSummary,
+  CodeQualityArm,
+  CodeQualityReport,
+  CodeQualityRunConfig,
+  CodeQualityRunResult,
+  PairedOutcomeSummary,
+} from "./contracts.js";
+
+export function buildCodeQualityReport(input: {
+  readonly config: CodeQualityRunConfig;
+  readonly scenarios: readonly string[];
+  readonly runs: readonly CodeQualityRunResult[];
+  readonly generatedAt?: string;
+}): CodeQualityReport {
+  const baseline = summarizeArm("baseline", input.runs);
+  const kontext = summarizeArm("kontext", input.runs);
+  const paired = summarizePairs(input.runs);
+  const evidenceStrength = classifyEvidenceStrength(input.scenarios.length, paired.pairs);
+  const hiddenAssertionUplift = kontext.hiddenAssertionPassRate - baseline.hiddenAssertionPassRate;
+  const taskSuccessUplift = kontext.taskSuccessRate - baseline.taskSuccessRate;
+  return {
+    schemaVersion: 1,
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    config: input.config,
+    scenarios: [...input.scenarios],
+    runs: [...input.runs],
+    summaries: [baseline, kontext],
+    paired,
+    hiddenAssertionUplift,
+    taskSuccessUplift,
+    evidenceStrength,
+    verdict: verdict({
+      evidenceStrength,
+      hiddenAssertionUplift,
+      taskSuccessUplift,
+      paired,
+    }),
+    limitations: limitations(evidenceStrength, input.scenarios.length, paired.pairs),
+  };
+}
+
+export function summarizeArm(
+  arm: CodeQualityArm,
+  allRuns: readonly CodeQualityRunResult[],
+): ArmSummary {
+  const runs = allRuns.filter((run) => run.arm === arm);
+  const eligibleRuns = runs.filter((run) => run.evaluationEligible);
+  const hiddenAssertions = eligibleRuns.flatMap((run) => run.hiddenAssertions);
+  const expectedTerms = eligibleRuns.reduce(
+    (total, run) => total + run.canonicalTermsPresent.length + run.canonicalTermsMissing.length,
+    0,
+  );
+  const summary: ArmSummary = {
+    arm,
+    runs: runs.length,
+    eligibleRuns: eligibleRuns.length,
+    runtimeCompletionRate: mean(runs.map((run) => Number(run.runtimeExitCode === 0))),
+    publicTestPassRate: mean(eligibleRuns.map((run) => Number(run.publicTestsPassed))),
+    hiddenAssertionPassRate: mean(hiddenAssertions.map((assertion) => Number(assertion.passed))),
+    taskSuccessRate: mean(eligibleRuns.map((run) => Number(isSuccessfulRun(run)))),
+    canonicalTermPassRate:
+      expectedTerms === 0
+        ? 0
+        : eligibleRuns.reduce((total, run) => total + run.canonicalTermsPresent.length, 0) /
+          expectedTerms,
+    scopeComplianceRate: mean(eligibleRuns.map((run) => Number(run.outOfScopePaths.length === 0))),
+    ...(arm === "kontext"
+      ? {
+          contextConsultationRate: mean(runs.map((run) => Number(run.contextConsulted))),
+        }
+      : {}),
+    meanDurationMilliseconds: mean(eligibleRuns.map((run) => run.durationMilliseconds)),
+    ...optionalMean(
+      "meanInputTokens",
+      eligibleRuns.map((run) => run.inputTokens),
+    ),
+    ...optionalMean(
+      "meanOutputTokens",
+      eligibleRuns.map((run) => run.outputTokens),
+    ),
+  };
+  return summary;
+}
+
+export function summarizePairs(runs: readonly CodeQualityRunResult[]): PairedOutcomeSummary {
+  const pairs = new Map<string, Partial<Record<CodeQualityArm, CodeQualityRunResult>>>();
+  for (const run of runs) {
+    const key = `${run.scenarioId}\u0000${run.repetition}`;
+    const pair = pairs.get(key) ?? {};
+    pair[run.arm] = run;
+    pairs.set(key, pair);
+  }
+  let kontextWins = 0;
+  let baselineWins = 0;
+  let ties = 0;
+  let completePairs = 0;
+  for (const pair of pairs.values()) {
+    if (!pair.baseline?.evaluationEligible || !pair.kontext?.evaluationEligible) continue;
+    completePairs += 1;
+    const comparison = compareRuns(pair.kontext, pair.baseline);
+    if (comparison > 0) kontextWins += 1;
+    else if (comparison < 0) baselineWins += 1;
+    else ties += 1;
+  }
+  const nonTies = kontextWins + baselineWins;
+  return {
+    pairs: completePairs,
+    kontextWins,
+    baselineWins,
+    ties,
+    ...(nonTies === 0
+      ? {}
+      : { twoSidedSignTestPValue: exactTwoSidedSignTest(kontextWins, baselineWins) }),
+  };
+}
+
+export function exactTwoSidedSignTest(successes: number, failures: number): number {
+  const trials = successes + failures;
+  if (trials === 0) return 1;
+  const tailEnd = Math.min(successes, failures);
+  let probability = 2 ** -trials;
+  let cumulative = probability;
+  for (let successesInTail = 1; successesInTail <= tailEnd; successesInTail += 1) {
+    probability *= (trials - successesInTail + 1) / successesInTail;
+    cumulative += probability;
+  }
+  return Math.min(1, 2 * cumulative);
+}
+
+export function renderCodeQualityMarkdown(report: CodeQualityReport): string {
+  const [baseline, kontext] = report.summaries;
+  if (!baseline || !kontext) throw new Error("Both arm summaries are required");
+  const percentage = (value: number): string => `${(value * 100).toFixed(1)}%`;
+  const tokens = (value: number | undefined): string =>
+    value === undefined ? "n/a" : Math.round(value).toLocaleString("en-US");
+  const pValue =
+    report.paired.twoSidedSignTestPValue === undefined
+      ? "n/a"
+      : report.paired.twoSidedSignTestPValue.toFixed(4);
+  return `# Kontext Brain code-quality A/B evaluation
+
+Generated: ${report.generatedAt}
+
+This is a **${report.evidenceStrength}** evaluation. Verdict: **${report.verdict}**.
+
+| Metric | Baseline | Kontext | Delta |
+|---|---:|---:|---:|
+| Eligible runs | ${baseline.eligibleRuns}/${baseline.runs} | ${kontext.eligibleRuns}/${kontext.runs} | — |
+| Runtime completion | ${percentage(baseline.runtimeCompletionRate)} | ${percentage(kontext.runtimeCompletionRate)} | ${percentage(kontext.runtimeCompletionRate - baseline.runtimeCompletionRate)} |
+| Public test pass | ${percentage(baseline.publicTestPassRate)} | ${percentage(kontext.publicTestPassRate)} | ${percentage(kontext.publicTestPassRate - baseline.publicTestPassRate)} |
+| Hidden policy assertions | ${percentage(baseline.hiddenAssertionPassRate)} | ${percentage(kontext.hiddenAssertionPassRate)} | ${percentage(report.hiddenAssertionUplift)} |
+| Whole-task success | ${percentage(baseline.taskSuccessRate)} | ${percentage(kontext.taskSuccessRate)} | ${percentage(report.taskSuccessUplift)} |
+| Canonical domain terms | ${percentage(baseline.canonicalTermPassRate)} | ${percentage(kontext.canonicalTermPassRate)} | ${percentage(kontext.canonicalTermPassRate - baseline.canonicalTermPassRate)} |
+| Exact-path scope | ${percentage(baseline.scopeComplianceRate)} | ${percentage(kontext.scopeComplianceRate)} | ${percentage(kontext.scopeComplianceRate - baseline.scopeComplianceRate)} |
+| Mean input tokens | ${tokens(baseline.meanInputTokens)} | ${tokens(kontext.meanInputTokens)} | — |
+| Mean output tokens | ${tokens(baseline.meanOutputTokens)} | ${tokens(kontext.meanOutputTokens)} | — |
+| Mean duration | ${Math.round(baseline.meanDurationMilliseconds)} ms | ${Math.round(kontext.meanDurationMilliseconds)} ms | ${Math.round(kontext.meanDurationMilliseconds - baseline.meanDurationMilliseconds)} ms |
+
+Paired outcomes: Kontext ${report.paired.kontextWins} wins, baseline ${report.paired.baselineWins} wins, ${report.paired.ties} ties across ${report.paired.pairs} pairs (two-sided exact sign-test p=${pValue}).
+
+Kontext context consultation rate: ${percentage(kontext.contextConsultationRate ?? 0)}.
+
+## Per-run evidence
+
+| Scenario | Repetition | Arm | Eligible | Hidden | Public | Terms | Scope | Context | Duration |
+|---|---:|---|---|---:|---|---|---|---|---:|
+${report.runs
+  .map((run) => {
+    const hiddenPassed = run.hiddenAssertions.filter((assertion) => assertion.passed).length;
+    return `| ${run.scenarioId} | ${run.repetition} | ${run.arm} | ${run.evaluationEligible ? "yes" : "no"} | ${hiddenPassed}/${run.hiddenAssertions.length} | ${run.publicTestsPassed ? "pass" : "fail"} | ${run.canonicalTermsMissing.length === 0 ? "pass" : `missing ${run.canonicalTermsMissing.join(", ")}`} | ${run.outOfScopePaths.length === 0 ? "pass" : `fail: ${run.outOfScopePaths.join(", ")}`} | ${run.contextConsulted ? "yes" : "no"} | ${Math.round(run.durationMilliseconds)} ms |`;
+  })
+  .join("\n")}
+
+## Limitations
+
+${report.limitations.map((limitation) => `- ${limitation}`).join("\n")}
+`;
+}
+
+function isSuccessfulRun(run: CodeQualityRunResult): boolean {
+  return (
+    run.runtimeExitCode === 0 &&
+    run.publicTestsPassed &&
+    run.hiddenAssertions.length > 0 &&
+    run.hiddenAssertions.every((assertion) => assertion.passed) &&
+    run.canonicalTermsMissing.length === 0 &&
+    run.outOfScopePaths.length === 0
+  );
+}
+
+function compareRuns(left: CodeQualityRunResult, right: CodeQualityRunResult): number {
+  const leftScore = runScore(left);
+  const rightScore = runScore(right);
+  for (let index = 0; index < leftScore.length; index += 1) {
+    const delta = (leftScore[index] ?? 0) - (rightScore[index] ?? 0);
+    if (delta !== 0) return Math.sign(delta);
+  }
+  return 0;
+}
+
+function runScore(run: CodeQualityRunResult): readonly number[] {
+  const hiddenRate = mean(run.hiddenAssertions.map((assertion) => Number(assertion.passed)));
+  const totalTerms = run.canonicalTermsPresent.length + run.canonicalTermsMissing.length;
+  return [
+    hiddenRate,
+    Number(isSuccessfulRun(run)),
+    totalTerms === 0 ? 0 : run.canonicalTermsPresent.length / totalTerms,
+    Number(run.outOfScopePaths.length === 0),
+    Number(run.publicTestsPassed),
+    Number(run.runtimeExitCode === 0),
+  ];
+}
+
+function classifyEvidenceStrength(
+  scenarioCount: number,
+  pairCount: number,
+): CodeQualityReport["evidenceStrength"] {
+  if (scenarioCount >= 10 && pairCount >= 100) return "release";
+  if (scenarioCount >= 10 && pairCount >= 30) return "pilot";
+  return "smoke";
+}
+
+function verdict(input: {
+  readonly evidenceStrength: CodeQualityReport["evidenceStrength"];
+  readonly hiddenAssertionUplift: number;
+  readonly taskSuccessUplift: number;
+  readonly paired: PairedOutcomeSummary;
+}): CodeQualityReport["verdict"] {
+  if (input.evidenceStrength !== "release") return "inconclusive";
+  const significant = (input.paired.twoSidedSignTestPValue ?? 1) <= 0.05;
+  if (significant && input.hiddenAssertionUplift > 0 && input.taskSuccessUplift >= 0) {
+    return "improvement";
+  }
+  if (significant && input.hiddenAssertionUplift < 0 && input.taskSuccessUplift <= 0) {
+    return "regression";
+  }
+  return "no_detected_difference";
+}
+
+function limitations(
+  evidenceStrength: CodeQualityReport["evidenceStrength"],
+  scenarioCount: number,
+  pairCount: number,
+): readonly string[] {
+  const values = [
+    "The hidden evaluator measures deterministic functional and terminology requirements, not general maintainability or human preference.",
+    "Codex generation is stochastic; repeated paired runs are required before a release claim.",
+    "The treatment has extra MCP latency and tokens, so quality and cost must be considered together.",
+  ];
+  if (evidenceStrength !== "release") {
+    values.unshift(
+      `Only ${scenarioCount} scenarios and ${pairCount} complete pairs were measured; this can show directional behavior but cannot establish a statistically supported release claim.`,
+    );
+  }
+  return values;
+}
+
+function mean(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+function optionalMean<Key extends "meanInputTokens" | "meanOutputTokens">(
+  key: Key,
+  values: readonly (number | undefined)[],
+): Partial<Record<Key, number>> {
+  const present = values.filter((value): value is number => value !== undefined);
+  return present.length === 0 ? {} : ({ [key]: mean(present) } as Partial<Record<Key, number>>);
+}

--- a/bench/src/code-quality-eval/scenarios.test.ts
+++ b/bench/src/code-quality-eval/scenarios.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { codeQualityScenarios } from "./scenarios.js";
+
+describe("code-quality hidden evaluators", () => {
+  it("accepts implementations that satisfy every held-out policy", async () => {
+    const implementations: Readonly<Record<string, Readonly<Record<string, unknown>>>> = {
+      "retry-policy": {
+        computeRetryDelay(failureIndex: number, baseMs: number): number {
+          if (
+            !Number.isInteger(failureIndex) ||
+            failureIndex < 0 ||
+            !Number.isInteger(baseMs) ||
+            baseMs < 0
+          ) {
+            throw new RangeError("invalid retry input");
+          }
+          return Math.min(baseMs * 3 ** failureIndex, 4_500);
+        },
+      },
+      "order-cancellation": {
+        cancellationOutcome(order: {
+          state: string;
+          shipmentId: string | null;
+          fraudHold: boolean;
+        }): string {
+          return order.state === "confirmed" && !order.shipmentId && order.fraudHold !== true
+            ? "revocable"
+            : "locked";
+        },
+      },
+      "service-credit-allocation": {
+        allocateServiceCredit(totalCents: number, accountIds: readonly string[]): object {
+          if (!Number.isInteger(totalCents) || totalCents < 0)
+            throw new RangeError("invalid total");
+          if (
+            accountIds.length === 0 ||
+            accountIds.some((id) => !id) ||
+            new Set(accountIds).size !== accountIds.length
+          ) {
+            throw new Error("invalid accounts");
+          }
+          const sorted = [...accountIds].sort();
+          const base = Math.floor(totalCents / sorted.length);
+          let remainder = totalCents % sorted.length;
+          const values = new Map(sorted.map((id) => [id, base]));
+          for (let index = sorted.length - 1; remainder > 0; index -= 1) {
+            const id = sorted[index];
+            if (!id) throw new Error("missing account");
+            values.set(id, base + 1);
+            remainder -= 1;
+          }
+          return Object.fromEntries(sorted.map((id) => [id, values.get(id)]));
+        },
+      },
+    };
+
+    for (const scenario of codeQualityScenarios) {
+      const implementation = implementations[scenario.scenarioId];
+      if (!implementation) throw new Error(`Missing implementation for ${scenario.scenarioId}`);
+      const result = await scenario.evaluateHidden(implementation);
+      expect(result.assertions.every((assertion) => assertion.passed)).toBe(true);
+    }
+  });
+});

--- a/bench/src/code-quality-eval/scenarios.ts
+++ b/bench/src/code-quality-eval/scenarios.ts
@@ -1,0 +1,328 @@
+import { isDeepStrictEqual } from "node:util";
+import type {
+  CodeQualityScenario,
+  HiddenAssertionResult,
+  HiddenEvaluationResult,
+} from "./contracts.js";
+
+export const codeQualityScenarios: readonly CodeQualityScenario[] = [
+  retryPolicyScenario(),
+  cancellationScenario(),
+  serviceCreditScenario(),
+];
+
+function retryPolicyScenario(): CodeQualityScenario {
+  return {
+    scenarioId: "retry-policy",
+    taskId: "task:code-quality:retry-policy",
+    intent: "Implement the current retry-delay policy without changing its public API.",
+    publicPrompt:
+      "Implement computeRetryDelay in src/policy.js according to the product's current retry policy. Keep the public API stable and run the tests.",
+    sourceFile: "src/policy.js",
+    initialSource: `export function computeRetryDelay(_failureIndex, _baseMs) {
+  throw new Error("Not implemented");
+}
+`,
+    publicTestSource: `import assert from "node:assert/strict";
+import test from "node:test";
+import { computeRetryDelay } from "../src/policy.js";
+
+test("the initial failure uses the base delay", () => {
+  assert.equal(computeRetryDelay(0, 100), 100);
+});
+`,
+    workItemId: "work-item:retry-delay",
+    plannedSymbolId: "planned-symbol:compute-retry-delay",
+    qualifiedName: "computeRetryDelay",
+    capabilityId: "capability:retry-policy",
+    canonicalTerms: ["RECOVERY_WINDOW_MS"],
+    rules: [
+      {
+        kind: "decision",
+        recordId: "decision:retry-delay-policy",
+        revisionId: "revision:retry-delay-policy:1",
+        statement:
+          "computeRetryDelay uses zero-based failureIndex and returns min(baseMs * 3 ** failureIndex, 4500). Both inputs must be non-negative integers; otherwise throw RangeError.",
+        evidenceId: "evidence:product:retry-policy",
+        evidenceText:
+          "The reliability owner approved a zero-based power-of-three retry curve capped at 4500 milliseconds, with RangeError for invalid integer inputs.",
+      },
+      {
+        kind: "domain_term",
+        recordId: "domain-term:recovery-window",
+        revisionId: "revision:recovery-window:1",
+        term: "Recovery Window",
+        definition:
+          "The maximum retry delay. Public implementation code names its 4500 millisecond constant RECOVERY_WINDOW_MS.",
+        avoid: ["max delay"],
+        evidenceId: "evidence:domain:recovery-window",
+        evidenceText:
+          "The domain owner named the retry cap Recovery Window and selected RECOVERY_WINDOW_MS as its code term.",
+      },
+      {
+        kind: "invariant",
+        recordId: "invariant:retry-delay-bounded",
+        revisionId: "revision:retry-delay-bounded:1",
+        statement: "A computed retry delay never exceeds the Recovery Window.",
+        evidenceId: "evidence:product:retry-bound",
+        evidenceText: "Operations requires all retry delays to stay at or below 4500 milliseconds.",
+      },
+    ],
+    evaluateHidden: async (module) => {
+      const compute = requiredFunction(module, "computeRetryDelay");
+      return {
+        assertions: [
+          callAssertion("triples-after-first-failure", compute, [1, 100], 300),
+          callAssertion("caps-at-recovery-window", compute, [5, 100], 4500),
+          callAssertion("accepts-zero-base", compute, [3, 0], 0),
+          throwAssertion("rejects-negative-index", compute, [-1, 100], RangeError),
+          throwAssertion("rejects-fractional-base", compute, [1, 2.5], RangeError),
+        ],
+      };
+    },
+  };
+}
+
+function cancellationScenario(): CodeQualityScenario {
+  return {
+    scenarioId: "order-cancellation",
+    taskId: "task:code-quality:order-cancellation",
+    intent: "Implement the current order-cancellation outcome policy.",
+    publicPrompt:
+      "Implement cancellationOutcome in src/policy.js according to the current order policy. Keep the public API stable and run the tests.",
+    sourceFile: "src/policy.js",
+    initialSource: `export function cancellationOutcome(_order) {
+  throw new Error("Not implemented");
+}
+`,
+    publicTestSource: `import assert from "node:assert/strict";
+import test from "node:test";
+import { cancellationOutcome } from "../src/policy.js";
+
+test("an unshipped confirmed order can be revoked", () => {
+  assert.equal(
+    cancellationOutcome({ state: "confirmed", shipmentId: null, fraudHold: false }),
+    "revocable",
+  );
+});
+`,
+    workItemId: "work-item:cancellation-outcome",
+    plannedSymbolId: "planned-symbol:cancellation-outcome",
+    qualifiedName: "cancellationOutcome",
+    capabilityId: "capability:order-cancellation",
+    canonicalTerms: ["hasRevocationEligibility"],
+    rules: [
+      {
+        kind: "decision",
+        recordId: "decision:order-revocation-policy",
+        revisionId: "revision:order-revocation-policy:1",
+        statement:
+          "cancellationOutcome returns 'revocable' only for state 'confirmed', no shipmentId, and fraudHold not true. Payment capture does not affect this decision. Every other order returns 'locked'.",
+        evidenceId: "evidence:product:order-revocation",
+        evidenceText:
+          "Order operations approved revocation for confirmed, unshipped, non-fraud-held orders even after payment capture.",
+      },
+      {
+        kind: "domain_term",
+        recordId: "domain-term:revocation-eligibility",
+        revisionId: "revision:revocation-eligibility:1",
+        term: "Revocation Eligibility",
+        definition:
+          "Whether an order may be cancelled under the approved policy. The implementation names the predicate hasRevocationEligibility.",
+        avoid: ["cancelable flag"],
+        evidenceId: "evidence:domain:revocation-eligibility",
+        evidenceText:
+          "The domain owner standardized Revocation Eligibility and the code predicate hasRevocationEligibility.",
+      },
+      {
+        kind: "invariant",
+        recordId: "invariant:shipped-order-locked",
+        revisionId: "revision:shipped-order-locked:1",
+        statement: "An order with a shipmentId is always locked against cancellation.",
+        evidenceId: "evidence:product:shipment-lock",
+        evidenceText:
+          "Fulfillment requires every shipment-created order to remain cancellation-locked.",
+      },
+    ],
+    evaluateHidden: async (module) => {
+      const outcome = requiredFunction(module, "cancellationOutcome");
+      return {
+        assertions: [
+          callAssertion(
+            "captured-payment-remains-revocable",
+            outcome,
+            [{ state: "confirmed", shipmentId: null, fraudHold: false, paymentCaptured: true }],
+            "revocable",
+          ),
+          callAssertion(
+            "fraud-hold-locks",
+            outcome,
+            [{ state: "confirmed", shipmentId: null, fraudHold: true }],
+            "locked",
+          ),
+          callAssertion(
+            "shipment-locks",
+            outcome,
+            [{ state: "confirmed", shipmentId: "shipment:1", fraudHold: false }],
+            "locked",
+          ),
+          callAssertion(
+            "draft-locks",
+            outcome,
+            [{ state: "draft", shipmentId: null, fraudHold: false }],
+            "locked",
+          ),
+        ],
+      };
+    },
+  };
+}
+
+function serviceCreditScenario(): CodeQualityScenario {
+  return {
+    scenarioId: "service-credit-allocation",
+    taskId: "task:code-quality:service-credit-allocation",
+    intent: "Allocate an integer service credit according to the approved account policy.",
+    publicPrompt:
+      "Implement allocateServiceCredit in src/policy.js according to the current service-credit policy. Keep the public API stable and run the tests.",
+    sourceFile: "src/policy.js",
+    initialSource: `export function allocateServiceCredit(_totalCents, _accountIds) {
+  throw new Error("Not implemented");
+}
+`,
+    publicTestSource: `import assert from "node:assert/strict";
+import test from "node:test";
+import { allocateServiceCredit } from "../src/policy.js";
+
+test("an evenly divisible credit is allocated equally", () => {
+  assert.deepEqual(allocateServiceCredit(6, ["account:b", "account:a", "account:c"]), {
+    "account:a": 2,
+    "account:b": 2,
+    "account:c": 2,
+  });
+});
+`,
+    workItemId: "work-item:service-credit-allocation",
+    plannedSymbolId: "planned-symbol:allocate-service-credit",
+    qualifiedName: "allocateServiceCredit",
+    capabilityId: "capability:service-credit",
+    canonicalTerms: ["serviceCreditByAccount"],
+    rules: [
+      {
+        kind: "decision",
+        recordId: "decision:service-credit-allocation",
+        revisionId: "revision:service-credit-allocation:1",
+        statement:
+          "allocateServiceCredit validates a non-negative integer totalCents and unique non-empty accountIds, sorts IDs lexicographically, divides equally, and assigns remainder cents from the lexicographically greatest ID backward. Return an object in ascending account ID insertion order.",
+        evidenceId: "evidence:finance:service-credit",
+        evidenceText:
+          "Finance approved deterministic equal allocation with remainder assigned from greatest account ID backward while output order remains ascending.",
+      },
+      {
+        kind: "domain_term",
+        recordId: "domain-term:service-credit",
+        revisionId: "revision:service-credit:1",
+        term: "Service Credit",
+        definition:
+          "An integer customer credit allocation. The result accumulator is named serviceCreditByAccount.",
+        avoid: ["refund split"],
+        evidenceId: "evidence:domain:service-credit",
+        evidenceText:
+          "The billing domain owner standardized Service Credit and serviceCreditByAccount.",
+      },
+      {
+        kind: "invariant",
+        recordId: "invariant:service-credit-conservation",
+        revisionId: "revision:service-credit-conservation:1",
+        statement: "Allocated cents sum exactly to totalCents and no allocation is negative.",
+        evidenceId: "evidence:finance:credit-conservation",
+        evidenceText: "The ledger requires exact conservation of every service-credit cent.",
+      },
+    ],
+    evaluateHidden: async (module) => {
+      const allocate = requiredFunction(module, "allocateServiceCredit");
+      return {
+        assertions: [
+          callAssertion(
+            "remainder-starts-at-greatest-id",
+            allocate,
+            [8, ["account:b", "account:a", "account:c"]],
+            { "account:a": 2, "account:b": 3, "account:c": 3 },
+          ),
+          callAssertion(
+            "single-remainder-goes-to-greatest-id",
+            allocate,
+            [7, ["account:b", "account:a", "account:c"]],
+            { "account:a": 2, "account:b": 2, "account:c": 3 },
+          ),
+          callAssertion(
+            "zero-credit-preserves-sorted-accounts",
+            allocate,
+            [0, ["account:z", "account:a"]],
+            { "account:a": 0, "account:z": 0 },
+          ),
+          throwAssertion(
+            "rejects-duplicate-accounts",
+            allocate,
+            [5, ["account:a", "account:a"]],
+            Error,
+          ),
+          throwAssertion("rejects-negative-total", allocate, [-1, ["account:a"]], RangeError),
+        ],
+      };
+    },
+  };
+}
+
+function requiredFunction(
+  module: Readonly<Record<string, unknown>>,
+  exportName: string,
+): (...args: readonly unknown[]) => unknown {
+  const value = module[exportName];
+  if (typeof value !== "function") throw new Error(`Missing function export ${exportName}`);
+  return value as (...args: readonly unknown[]) => unknown;
+}
+
+function callAssertion(
+  assertionId: string,
+  operation: (...args: readonly unknown[]) => unknown,
+  args: readonly unknown[],
+  expected: unknown,
+): HiddenAssertionResult {
+  try {
+    const actual = operation(...args);
+    return isDeepStrictEqual(actual, expected)
+      ? { assertionId, passed: true }
+      : {
+          assertionId,
+          passed: false,
+          diagnostic: `Expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`,
+        };
+  } catch (error) {
+    return { assertionId, passed: false, diagnostic: errorMessage(error) };
+  }
+}
+
+function throwAssertion(
+  assertionId: string,
+  operation: (...args: readonly unknown[]) => unknown,
+  args: readonly unknown[],
+  expected: new (...args: never[]) => Error,
+): HiddenAssertionResult {
+  try {
+    operation(...args);
+    return { assertionId, passed: false, diagnostic: `Expected ${expected.name}` };
+  } catch (error) {
+    return error instanceof expected
+      ? { assertionId, passed: true }
+      : {
+          assertionId,
+          passed: false,
+          diagnostic: `Expected ${expected.name}, received ${errorMessage(error)}`,
+        };
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}

--- a/bench/src/code-quality-eval/workspace.ts
+++ b/bench/src/code-quality-eval/workspace.ts
@@ -1,0 +1,151 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import type { CodeQualityScenario, HiddenEvaluationResult } from "./contracts.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface ScenarioWorkspace {
+  readonly workspacePath: string;
+  readonly baseRevision: string;
+}
+
+export interface WorkspaceCommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export async function createScenarioWorkspace(
+  scenario: CodeQualityScenario,
+): Promise<ScenarioWorkspace> {
+  const workspacePath = await mkdtemp(
+    path.join(tmpdir(), `kontext-code-eval-${scenario.scenarioId}-`),
+  );
+  await mkdir(path.join(workspacePath, "src"), { recursive: true });
+  await mkdir(path.join(workspacePath, "test"), { recursive: true });
+  await writeFile(
+    path.join(workspacePath, "package.json"),
+    `${JSON.stringify(
+      {
+        name: `code-quality-${scenario.scenarioId}`,
+        version: "1.0.0",
+        private: true,
+        type: "module",
+        scripts: { test: "node --test" },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(path.join(workspacePath, scenario.sourceFile), scenario.initialSource);
+  await writeFile(path.join(workspacePath, "test", "public.test.js"), scenario.publicTestSource);
+  await writeFile(
+    path.join(workspacePath, "TASK.md"),
+    `# Task\n\n${scenario.publicPrompt}\n\nOnly edit \`${scenario.sourceFile}\`.\n`,
+  );
+  await git(workspacePath, ["init", "-q"]);
+  await git(workspacePath, ["add", "."]);
+  await git(workspacePath, [
+    "-c",
+    "user.name=Kontext Code Eval",
+    "-c",
+    "user.email=code-eval@example.invalid",
+    "commit",
+    "-qm",
+    "fixture baseline",
+  ]);
+  return {
+    workspacePath,
+    baseRevision: (await git(workspacePath, ["rev-parse", "HEAD"])).stdout.trim(),
+  };
+}
+
+export async function evaluateWorkspace(
+  scenario: CodeQualityScenario,
+  workspacePath: string,
+): Promise<{
+  readonly publicTestsPassed: boolean;
+  readonly hidden: HiddenEvaluationResult;
+  readonly source: string;
+  readonly changedPaths: readonly string[];
+  readonly patch: string;
+}> {
+  const publicTests = await runWorkspaceCommand(workspacePath, "npm", [
+    "test",
+    "--",
+    "--test-reporter=spec",
+  ]);
+  const sourcePath = path.join(workspacePath, scenario.sourceFile);
+  const source = await readFile(sourcePath, "utf8").catch(() => "");
+  let hidden: HiddenEvaluationResult;
+  try {
+    const moduleUrl = `${pathToFileURL(sourcePath).href}?eval=${Date.now()}-${Math.random()}`;
+    const loaded = (await import(moduleUrl)) as Readonly<Record<string, unknown>>;
+    hidden = await scenario.evaluateHidden(loaded);
+  } catch (error) {
+    hidden = {
+      assertions: [
+        {
+          assertionId: "module-load",
+          passed: false,
+          diagnostic: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    };
+  }
+  const changedPaths = (await git(workspacePath, ["status", "--short"])).stdout
+    .split("\n")
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean)
+    .sort();
+  const patch = (await git(workspacePath, ["diff", "--binary", "HEAD", "--"])).stdout;
+  return {
+    publicTestsPassed: publicTests.exitCode === 0,
+    hidden,
+    source,
+    changedPaths,
+    patch,
+  };
+}
+
+export async function runWorkspaceCommand(
+  cwd: string,
+  command: string,
+  args: readonly string[],
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<WorkspaceCommandResult> {
+  try {
+    const result = await execFileAsync(command, args, {
+      cwd,
+      env: environment,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    if (isExecError(error)) {
+      return {
+        exitCode: typeof error.code === "number" ? error.code : 1,
+        stdout: error.stdout ?? "",
+        stderr: error.stderr ?? error.message,
+      };
+    }
+    throw error;
+  }
+}
+
+async function git(cwd: string, args: readonly string[]): Promise<WorkspaceCommandResult> {
+  return runWorkspaceCommand(cwd, "git", args);
+}
+
+function isExecError(error: unknown): error is Error & {
+  readonly code?: number | string;
+  readonly stdout?: string;
+  readonly stderr?: string;
+} {
+  return error instanceof Error;
+}

--- a/bench/tsconfig.code-quality.json
+++ b/bench/tsconfig.code-quality.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/code-quality-eval/**/*.ts"]
+}

--- a/bench/vitest.code-quality.config.ts
+++ b/bench/vitest.code-quality.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    include: ["bench/src/code-quality-eval/**/*.test.ts"],
+    testTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
Lands the paired code-quality evaluation harness and adds a Claude Code runtime beside the Codex one.

## What it measures

Each scenario keeps its policy only in a private sidecar, so the public prompt and public test underdetermine the answer. A baseline smoke run (6 runs, `gpt-5.6-terra` medium) confirms the separation holds:

| metric | baseline |
|---|---:|
| public test pass rate | 100% |
| hidden assertion pass rate | 28.6% |
| canonical term pass rate | **0%** |
| task success rate | 0% |
| scope compliance | 100% |

Repeated runs failed the identical assertion sets, so the fixtures are stable as well as held out.

## Defects found by running it

- `extractKontextTools` sliced with `lastIndexOf("__") + 2`. A bare name like `kontext_begin_logic` has no separator, so `-1 + 2` cut its first character and it failed the `kontext_` pattern. `contextConsulted` requires both `prepare_task` and `begin_logic`, so **every treatment run scored ineligible and the paired analysis had zero pairs**. The committed test for this was already failing.
- The fixtures declared `intendedIdentity.language: "typescript"` for `src/policy.js`. `languageForPath` maps `.js` to `"javascript"`, so `kontext_check_change` refused even a fully correct implementation — the arm measured error recovery, not context quality.
- The treatment prompt asked for "current ISO timestamps" while `kontext_check_change` requires `nextAttemptAt`, so the call failed schema validation before reaching verification.

## Claude runtime

`--runtime claude` selects the Claude Code subscription. The runtime is now a parameter rather than a constant: Evidence egress and normative revisions authorize the selected provider, and the treatment arm reaches the sidecar through a temporary `--mcp-config` scoped to that scenario's private data directory, with `--allowedTools` limited to the Kontext tools plus edit primitives.

Verified against the shipped `server.mjs` with `runtimeProvider: "claude"`:

- `editingAllowed: true`
- full mandatory context delivered (5,974 chars vs 1,043 when the provider is not authorized)
- `kontext_check_change` returns a verification plan

The egress gate was verified to still fail closed: an unauthorized provider gets `editingAllowed: false` and 82.5% of the context withheld.

## Known limitation

Treatment runs cannot execute in the current environment. `codex exec` cancels every MCP tool call with `user cancelled MCP tool call`, reproduced with a ten-line MCP server, so it is not specific to this plugin. The Claude path additionally needs a live `claude login`.

## Validation

- `tsc -p bench/tsconfig.code-quality.json`
- harness suite: 14 passed
- repository suite: 338 passed, 14 skipped
- `biome check bench/src/code-quality-eval`

🤖 Generated with [Claude Code](https://claude.com/claude-code)