### PR TITLE
feat: analyze Python Code Symbols

### DIFF
--- a/packages/code/src/domain.ts
+++ b/packages/code/src/domain.ts
@@ -1,4 +1,4 @@
-export type CodeLanguage = "typescript" | "javascript";
+export type CodeLanguage = "typescript" | "javascript" | "python";
 
 export type CodeSymbolKind =
   | "module"

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./domain.js";
+export * from "./python-code-provider.js";
 export * from "./typescript-code-provider.js";
 export * from "./code-resource-snapshot.js";
 export * from "./code-impact-index.js";

--- a/packages/code/src/python-code-provider.ts
+++ b/packages/code/src/python-code-provider.ts
@@ -1,0 +1,348 @@
+import { createHash } from "node:crypto";
+import type {
+  CodeAnalysisInput,
+  CodeFileAnalysis,
+  CodeSymbolIdentity,
+  CodeSymbolKind,
+  CodeSymbolRecord,
+  LanguageCodeProvider,
+} from "./domain.js";
+
+/**
+ * Python has no type checker in this pipeline, so this provider reports
+ * "syntactic" support rather than the "certified" support the TypeScript
+ * provider claims. Behaviour identity therefore comes from a canonical token
+ * stream instead of a typed syntax tree.
+ *
+ * The token stream drops comments, docstrings, blank lines, and inner
+ * whitespace, and normalizes string and numeric literals, so a format-only edit
+ * leaves contentHash unchanged exactly as it does for TypeScript.
+ */
+export class PythonCodeProvider implements LanguageCodeProvider {
+  readonly language = "python" as const;
+  readonly semanticSupport = "syntactic" as const;
+
+  analyze(input: CodeAnalysisInput): CodeFileAnalysis {
+    const relativePath = normalizeRelativePath(input.targetPath);
+    const file = input.files.find(
+      (candidate) => normalizeRelativePath(candidate.path) === relativePath,
+    );
+    if (file === undefined) {
+      throw new Error(`Target file "${relativePath}" is missing from the Codebase snapshot`);
+    }
+    const lines = file.content.split(/\r?\n/);
+    const declarations = parseDeclarations(lines);
+    const symbols: CodeSymbolRecord[] = [];
+    let position = 1;
+
+    symbols.push(
+      record({
+        codebaseId: input.codebaseId,
+        relativePath,
+        kind: "module",
+        qualifiedName: "<module>",
+        signature: relativePath,
+        bodyLines: lines,
+        text: file.content,
+        behaviorBearing: false,
+        exported: true,
+        position: 0,
+      }),
+    );
+
+    for (const declaration of declarations) {
+      const text = lines.slice(declaration.startLine, declaration.endLine + 1).join("\n");
+      symbols.push(
+        record({
+          codebaseId: input.codebaseId,
+          relativePath,
+          kind: declaration.kind,
+          qualifiedName: declaration.qualifiedName,
+          signature: declaration.signature,
+          bodyLines: lines.slice(declaration.startLine, declaration.endLine + 1),
+          text,
+          behaviorBearing: declaration.kind !== "class" && declaration.kind !== "constant",
+          exported: declaration.exported,
+          position: position++,
+        }),
+      );
+    }
+
+    return {
+      codebaseId: input.codebaseId,
+      relativePath,
+      language: "python",
+      sourceText: file.content,
+      contentHash: sha256(canonicalTokens(lines)),
+      symbols,
+      relationships: [],
+      unresolvedRelationships: [],
+      diagnostics: [],
+    };
+  }
+}
+
+interface Declaration {
+  readonly kind: CodeSymbolKind;
+  readonly qualifiedName: string;
+  readonly signature: string;
+  readonly startLine: number;
+  readonly endLine: number;
+  readonly exported: boolean;
+}
+
+const definitionPattern = /^(\s*)(async\s+def|def|class)\s+([A-Za-z_][A-Za-z0-9_]*)\s*(.*)$/;
+const constantPattern = /^([A-Z][A-Z0-9_]*)\s*(?::[^=]+)?=\s*(.+)$/;
+
+function parseDeclarations(lines: readonly string[]): readonly Declaration[] {
+  const declarations: Declaration[] = [];
+  const open: { indent: number; name: string; kind: CodeSymbolKind }[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+    const indent = line.length - line.trimStart().length;
+    while (open.length > 0 && indent <= (open.at(-1)?.indent ?? 0)) open.pop();
+
+    const match = definitionPattern.exec(line);
+    if (match) {
+      const [, , keyword, name, rest] = match;
+      const enclosing = open.at(-1);
+      const isClass = keyword === "class";
+      // Only a function directly inside a class is a method; anything nested
+      // deeper is a closure and is not addressable as its own logic unit.
+      const kind: CodeSymbolKind = isClass
+        ? "class"
+        : enclosing?.kind === "class"
+          ? "method"
+          : "function";
+      const qualifiedName = enclosing ? `${enclosing.name}.${name}` : (name as string);
+      if (!isClass && open.some((entry) => entry.kind !== "class")) {
+        continue;
+      }
+      declarations.push({
+        kind,
+        qualifiedName,
+        signature: declarationSignature(lines, index, rest ?? ""),
+        startLine: index,
+        endLine: blockEnd(lines, index, indent),
+        exported: !(name as string).startsWith("_"),
+      });
+      open.push({ indent, name: qualifiedName, kind });
+      continue;
+    }
+
+    if (indent === 0) {
+      const constant = constantPattern.exec(line.trim());
+      if (constant) {
+        declarations.push({
+          kind: "constant",
+          qualifiedName: constant[1] as string,
+          signature: `${constant[1]} = <value>`,
+          startLine: index,
+          endLine: index,
+          exported: true,
+        });
+      }
+    }
+  }
+  return declarations;
+}
+
+/**
+ * A definition header can wrap across lines, so the signature is read to its
+ * balanced closing parenthesis and then normalized to a single spacing form.
+ */
+function declarationSignature(lines: readonly string[], startLine: number, rest: string): string {
+  let text = rest;
+  let depth = countDepth(rest);
+  let index = startLine;
+  while (depth > 0 && index + 1 < lines.length) {
+    index += 1;
+    const next = lines[index] ?? "";
+    text += ` ${next.trim()}`;
+    depth += countDepth(next);
+  }
+  return text.replace(/#.*$/, "").replace(/:\s*$/, "").replace(/\s+/g, " ").trim();
+}
+
+function countDepth(text: string): number {
+  let depth = 0;
+  for (const character of text) {
+    if (character === "(" || character === "[" || character === "{") depth += 1;
+    if (character === ")" || character === "]" || character === "}") depth -= 1;
+  }
+  return depth;
+}
+
+function blockEnd(lines: readonly string[], startLine: number, indent: number): number {
+  let end = startLine;
+  for (let index = startLine + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (!line.trim()) continue;
+    const lineIndent = line.length - line.trimStart().length;
+    if (lineIndent <= indent) break;
+    end = index;
+  }
+  return end;
+}
+
+function record(input: {
+  readonly codebaseId: string;
+  readonly relativePath: string;
+  readonly kind: CodeSymbolKind;
+  readonly qualifiedName: string;
+  readonly signature: string;
+  readonly bodyLines: readonly string[];
+  readonly text: string;
+  readonly behaviorBearing: boolean;
+  readonly exported: boolean;
+  readonly position: number;
+}): CodeSymbolRecord {
+  const identity: CodeSymbolIdentity = {
+    codebaseId: input.codebaseId,
+    relativePath: input.relativePath,
+    language: "python",
+    kind: input.kind,
+    qualifiedName: input.qualifiedName,
+    signatureDiscriminator: input.signature,
+  };
+  return {
+    symbolId: `code-symbol:${sha256(JSON.stringify(identity))}`,
+    sourceChunkId: `symbol:${identity.kind}:${sha256(
+      JSON.stringify([identity.qualifiedName, identity.signatureDiscriminator]),
+    ).slice(0, 24)}`,
+    identity,
+    behaviorBearing: input.behaviorBearing,
+    exported: input.exported,
+    signature: input.signature,
+    contentHash: sha256(canonicalTokens(input.bodyLines)),
+    text: input.text,
+    position: input.position,
+    semanticSupport: "syntactic",
+  };
+}
+
+/**
+ * Emits a canonical token stream. Indentation becomes relative depth markers so
+ * re-indenting a block does not change its behaviour identity, while a real
+ * nesting change still does.
+ */
+export function canonicalTokens(lines: readonly string[]): string {
+  const tokens: string[] = [];
+  const indents: number[] = [];
+  let baseIndent: number | undefined;
+  let expectDocstring = true;
+
+  for (const rawLine of lines) {
+    const stripped = stripComment(rawLine);
+    if (!stripped.trim()) continue;
+    const indent = stripped.length - stripped.trimStart().length;
+    baseIndent ??= indent;
+    const relative = Math.max(0, indent - baseIndent);
+    while (indents.length > 0 && relative < (indents.at(-1) ?? 0)) {
+      indents.pop();
+      tokens.push("DEDENT");
+    }
+    if (relative > (indents.at(-1) ?? 0)) {
+      indents.push(relative);
+      tokens.push("INDENT");
+    }
+    const lineTokens = tokenizeLine(stripped.trim());
+    // A bare string statement opening a block is documentation, matching how
+    // the TypeScript provider drops comments before hashing.
+    if (expectDocstring && lineTokens.length === 1 && lineTokens[0]?.startsWith("STR:")) {
+      expectDocstring = false;
+      continue;
+    }
+    expectDocstring =
+      /^(?:def|class|async)\b/.test(stripped.trim()) || lineTokens.at(-1) === "OP::";
+    tokens.push(...lineTokens, "NEWLINE");
+  }
+  return tokens.join(" ");
+}
+
+function stripComment(line: string): string {
+  let quote: string | undefined;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (quote) {
+      if (character === "\\") index += 1;
+      else if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") quote = character;
+    else if (character === "#") return line.slice(0, index);
+  }
+  return line;
+}
+
+function tokenizeLine(line: string): string[] {
+  const tokens: string[] = [];
+  let index = 0;
+  while (index < line.length) {
+    const character = line[index] as string;
+    if (/\s/.test(character)) {
+      index += 1;
+      continue;
+    }
+    const triple = line.slice(index, index + 3);
+    if (triple === '"""' || triple === "'''") {
+      const close = line.indexOf(triple, index + 3);
+      const end = close === -1 ? line.length : close + 3;
+      tokens.push(`STR:${JSON.stringify(line.slice(index + 3, Math.max(index + 3, end - 3)))}`);
+      index = end;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      let cursor = index + 1;
+      let value = "";
+      while (cursor < line.length && line[cursor] !== character) {
+        if (line[cursor] === "\\") cursor += 1;
+        value += line[cursor] ?? "";
+        cursor += 1;
+      }
+      tokens.push(`STR:${JSON.stringify(value)}`);
+      index = cursor + 1;
+      continue;
+    }
+    const remainder = line.slice(index);
+    const number = /^\d[\d_]*(?:\.\d[\d_]*)?(?:[eE][+-]?\d+)?/.exec(remainder);
+    if (number) {
+      tokens.push(`NUM:${Number(number[0].replaceAll("_", ""))}`);
+      index += number[0].length;
+      continue;
+    }
+    const name = /^[A-Za-z_][A-Za-z0-9_]*/.exec(remainder);
+    if (name) {
+      // A string prefix such as f or rb belongs to the literal that follows.
+      const next = line[index + name[0].length];
+      if (/^[A-Za-z]{1,2}$/.test(name[0]) && (next === '"' || next === "'")) {
+        index += name[0].length;
+        continue;
+      }
+      tokens.push(`NAME:${name[0]}`);
+      index += name[0].length;
+      continue;
+    }
+    const operator =
+      /^(?:\*\*=|\/\/=|>>=|<<=|\.\.\.|==|!=|<=|>=|->|:=|\*\*|\/\/|<<|>>|[+\-*/%@&|^~<>()[\]{},:.;=])/.exec(
+        remainder,
+      );
+    if (operator) {
+      tokens.push(`OP:${operator[0]}`);
+      index += operator[0].length;
+      continue;
+    }
+    index += 1;
+  }
+  return tokens;
+}
+
+function normalizeRelativePath(value: string): string {
+  return value.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/packages/code/tests/python-code-provider.test.ts
+++ b/packages/code/tests/python-code-provider.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { PythonCodeProvider } from "../src/python-code-provider.js";
+
+const provider = new PythonCodeProvider();
+
+function analyze(content: string, targetPath = "src/policy.py") {
+  return provider.analyze({
+    codebaseId: "codebase:test",
+    targetPath,
+    files: [{ path: targetPath, content }],
+  });
+}
+
+function symbol(content: string, qualifiedName: string) {
+  const found = analyze(content).symbols.find(
+    (candidate) => candidate.identity.qualifiedName === qualifiedName,
+  );
+  if (!found) throw new Error(`Missing symbol ${qualifiedName}`);
+  return found;
+}
+
+const implementation = `RECOVERY_WINDOW_MS = 4500
+
+
+def compute_retry_delay(failure_index: int, base_ms: int) -> int:
+    """Return the approved delay."""
+    if failure_index < 0:
+        raise ValueError("negative")
+    return min(base_ms * 3 ** failure_index, RECOVERY_WINDOW_MS)
+
+
+class RetryPolicy:
+    def describe(self) -> str:
+        return "policy"
+
+    def _internal(self) -> None:
+        return None
+`;
+
+describe("PythonCodeProvider", () => {
+  it("reports syntactic support because Python has no type checker here", () => {
+    expect(provider.language).toBe("python");
+    expect(provider.semanticSupport).toBe("syntactic");
+    expect(symbol(implementation, "compute_retry_delay").semanticSupport).toBe("syntactic");
+  });
+
+  it("extracts module, function, class, method, and constant symbols", () => {
+    const analysis = analyze(implementation);
+    const byName = new Map(
+      analysis.symbols.map((record) => [record.identity.qualifiedName, record] as const),
+    );
+    expect(byName.get("<module>")?.identity.kind).toBe("module");
+    expect(byName.get("compute_retry_delay")?.identity.kind).toBe("function");
+    expect(byName.get("RetryPolicy")?.identity.kind).toBe("class");
+    expect(byName.get("RetryPolicy.describe")?.identity.kind).toBe("method");
+    expect(byName.get("RECOVERY_WINDOW_MS")?.identity.kind).toBe("constant");
+    expect(analysis.language).toBe("python");
+  });
+
+  it("treats functions and methods as behaviour bearing but not classes or constants", () => {
+    expect(symbol(implementation, "compute_retry_delay").behaviorBearing).toBe(true);
+    expect(symbol(implementation, "RetryPolicy.describe").behaviorBearing).toBe(true);
+    expect(symbol(implementation, "RetryPolicy").behaviorBearing).toBe(false);
+    expect(symbol(implementation, "RECOVERY_WINDOW_MS").behaviorBearing).toBe(false);
+  });
+
+  it("marks an underscore-prefixed name as not exported", () => {
+    expect(symbol(implementation, "RetryPolicy.describe").exported).toBe(true);
+    expect(symbol(implementation, "RetryPolicy._internal").exported).toBe(false);
+  });
+
+  it("keeps behaviour identity stable across a format-only edit", () => {
+    // Indentation is semantic in Python, so a format-only edit re-indents the
+    // whole block uniformly and changes only spacing inside lines.
+    const reformatted = `RECOVERY_WINDOW_MS = 4500
+
+
+def compute_retry_delay(failure_index: int, base_ms: int) -> int:
+        """Return the approved delay."""
+
+        if failure_index < 0:
+                raise ValueError("negative")
+
+        return min(base_ms*3**failure_index,   RECOVERY_WINDOW_MS)
+
+
+class RetryPolicy:
+    def describe(self) -> str:
+        return "policy"
+
+    def _internal(self) -> None:
+        return None
+`;
+    expect(symbol(reformatted, "compute_retry_delay").contentHash).toBe(
+      symbol(implementation, "compute_retry_delay").contentHash,
+    );
+  });
+
+  it("changes behaviour identity when real nesting changes", () => {
+    const nested = implementation.replace(
+      "    return min(base_ms * 3 ** failure_index, RECOVERY_WINDOW_MS)",
+      "    if base_ms > 0:\n        return min(base_ms * 3 ** failure_index, RECOVERY_WINDOW_MS)",
+    );
+    expect(symbol(nested, "compute_retry_delay").contentHash).not.toBe(
+      symbol(implementation, "compute_retry_delay").contentHash,
+    );
+  });
+
+  it("ignores comments and docstrings when deriving behaviour identity", () => {
+    const annotated = implementation
+      .replace('    """Return the approved delay."""', '    """Completely different prose."""')
+      .replace("    return min(", "    # explain the cap\n    return min(");
+    expect(symbol(annotated, "compute_retry_delay").contentHash).toBe(
+      symbol(implementation, "compute_retry_delay").contentHash,
+    );
+  });
+
+  it("changes behaviour identity when the body changes", () => {
+    const changed = implementation.replace(
+      "base_ms * 3 ** failure_index",
+      "base_ms * 2 ** failure_index",
+    );
+    expect(symbol(changed, "compute_retry_delay").contentHash).not.toBe(
+      symbol(implementation, "compute_retry_delay").contentHash,
+    );
+  });
+
+  it("changes the symbol ID when the signature changes", () => {
+    const changed = implementation.replace(
+      "def compute_retry_delay(failure_index: int, base_ms: int) -> int:",
+      "def compute_retry_delay(failure_index: int, base_ms: float) -> float:",
+    );
+    expect(symbol(changed, "compute_retry_delay").symbolId).not.toBe(
+      symbol(implementation, "compute_retry_delay").symbolId,
+    );
+  });
+
+  it("keeps the symbol ID stable when only the body changes", () => {
+    const changed = implementation.replace(
+      "base_ms * 3 ** failure_index",
+      "base_ms * 2 ** failure_index",
+    );
+    expect(symbol(changed, "compute_retry_delay").symbolId).toBe(
+      symbol(implementation, "compute_retry_delay").symbolId,
+    );
+  });
+
+  it("reads a signature that wraps across lines", () => {
+    const wrapped = `def allocate(
+    total_cents: int,
+    account_ids: list[str],
+) -> dict[str, int]:
+    return {}
+`;
+    expect(symbol(wrapped, "allocate").signature).toBe(
+      "( total_cents: int, account_ids: list[str], ) -> dict[str, int]",
+    );
+  });
+
+  it("does not expose a closure as its own symbol", () => {
+    const withClosure = `def outer(value: int) -> int:
+    def inner(x: int) -> int:
+        return x + 1
+
+    return inner(value)
+`;
+    const names = analyze(withClosure).symbols.map((record) => record.identity.qualifiedName);
+    expect(names).toContain("outer");
+    expect(names).not.toContain("outer.inner");
+  });
+
+  it("handles async definitions", () => {
+    const asyncSource = `async def fetch(url: str) -> str:
+    return url
+`;
+    expect(symbol(asyncSource, "fetch").identity.kind).toBe("function");
+    expect(symbol(asyncSource, "fetch").behaviorBearing).toBe(true);
+  });
+});

--- a/packages/tool-server/src/workspace-code-symbol-observer.ts
+++ b/packages/tool-server/src/workspace-code-symbol-observer.ts
@@ -2,7 +2,11 @@ import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFile, realpath } from "node:fs/promises";
 import path from "node:path";
-import { type CodeSymbolIdentity, TypeScriptCodeProvider } from "@kontext-brain/code";
+import {
+  type CodeSymbolIdentity,
+  PythonCodeProvider,
+  TypeScriptCodeProvider,
+} from "@kontext-brain/code";
 import {
   type WorkspaceObservationSnapshot,
   captureWorkspaceSnapshot,
@@ -23,7 +27,8 @@ export interface WorkspaceCodeSymbolSnapshot {
 
 const maxSourceFiles = 10_000;
 const maxSourceBytes = 32 * 1024 * 1024;
-const codeExtension = /\.(?:[cm]?[jt]sx?)$/i;
+const codeExtension = /\.(?:[cm]?[jt]sx?|py)$/i;
+const pythonExtension = /\.py$/i;
 
 export async function captureWorkspaceCodeSymbols(
   workspacePath: string,
@@ -62,15 +67,18 @@ export async function captureWorkspaceCodeSymbols(
       .filter((targetPath) => codeExtension.test(targetPath) && sourcePathSet.has(targetPath)),
   );
   const codebaseId = await resolveCodebaseId(workspace);
-  const provider = new TypeScriptCodeProvider();
+  const typescriptProvider = new TypeScriptCodeProvider();
+  const pythonProvider = new PythonCodeProvider();
   const symbols = targets
     .flatMap((targetPath) =>
-      provider.analyze({ codebaseId, targetPath, files }).symbols.map((symbol) => ({
-        symbolId: symbol.symbolId,
-        identity: symbol.identity,
-        behaviorBearing: symbol.behaviorBearing,
-        contentHash: symbol.contentHash,
-      })),
+      (pythonExtension.test(targetPath) ? pythonProvider : typescriptProvider)
+        .analyze({ codebaseId, targetPath, files })
+        .symbols.map((symbol) => ({
+          symbolId: symbol.symbolId,
+          identity: symbol.identity,
+          behaviorBearing: symbol.behaviorBearing,
+          contentHash: symbol.contentHash,
+        })),
     )
     .sort(compareSymbolState);
   return {


### PR DESCRIPTION
## Problem

`.py` files were filtered out before analysis. Measured directly:

```
python symbols : 0 []
typescript syms: 2 [ '<module>', 'computeRetryDelay' ]
```

`CodeLanguage` was `"typescript" | "javascript"`, the only provider was `TypeScriptCodeProvider`, and `codeExtension` excluded `.py`. A Python workspace therefore produced zero symbols, no Planned Symbol could bind, and `kontext_check_change` refused with "Cannot verify unbound Planned Symbols".

Only the treatment path fails that way — a baseline or retrieval arm runs normally — so a Python codebase could read as a large regression that was really an unsupported language.

## Approach

`PythonCodeProvider` implements the same `LanguageCodeProvider` contract, and the observer dispatches on file extension.

Python has no type checker in this pipeline, so the provider honestly reports `semanticSupport: "syntactic"` rather than the `"certified"` support TypeScript claims. The domain already carried that distinction.

Behaviour identity comes from a canonical token stream rather than a typed syntax tree, matching TypeScript's `canonicalSyntax` semantics:

| edit | contentHash | symbolId |
|---|---|---|
| comments, docstrings, blank lines | unchanged | unchanged |
| inner whitespace | unchanged | unchanged |
| uniform re-indentation of a block | unchanged | unchanged |
| real nesting change | **changed** | unchanged |
| body change | **changed** | unchanged |
| signature change | changed | **changed** |

Indentation is semantic in Python, so it becomes relative depth markers: re-indenting a whole block uniformly is format-only, but adding a level of nesting is not.

Symbol kinds: module, function, class, method, and module-level constant. Functions and methods are behaviour bearing; classes and constants are not. A function nested inside another function is a closure and is not addressable as its own logic unit. Underscore-prefixed names are not exported.

## Verified end to end

```
baseline symbols: [ '<module>', 'compute_retry_delay' ]
current  symbols: [ '<module>', 'compute_retry_delay', 'RECOVERY_WINDOW_MS' ]
changed symbol ids: 1
planned symbol bindings: 1 intended_identity issues: 0
```

## Validation

- `corepack pnpm -r build`, `corepack pnpm -r typecheck`
- 13 new provider tests; repository suite 351 passed, 14 skipped
- `biome check packages/code packages/tool-server`

## Not covered

Import relationships are not extracted, so `relationships` is empty for Python. Symbol extraction, behaviour identity, and Planned Symbol binding are the parts the Accurate Code workflow depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)