### PR TITLE
feat: run code-quality scenarios in TypeScript and Python

### DIFF
--- a/bench/src/code-quality-eval/contracts.ts
+++ b/bench/src/code-quality-eval/contracts.ts
@@ -22,6 +22,18 @@ export interface HiddenEvaluationResult {
   readonly assertions: readonly HiddenAssertionResult[];
 }
 
+/**
+ * A Python scenario cannot hand a JavaScript module to evaluateHidden, so its
+ * held-out checks are declared as data and executed by a Python driver.
+ */
+export interface PythonHiddenCheck {
+  readonly assertionId: string;
+  readonly functionName: string;
+  readonly args: readonly unknown[];
+  readonly expected?: unknown;
+  readonly throws?: string;
+}
+
 export interface CodeQualityScenario {
   readonly scenarioId: string;
   readonly taskId: string;
@@ -30,6 +42,10 @@ export interface CodeQualityScenario {
   readonly sourceFile: string;
   readonly initialSource: string;
   readonly publicTestSource: string;
+  /** Defaults to test/public.test.js; Python scenarios use test/public_test.py. */
+  readonly testFile?: string;
+  /** Required for a Python scenario, which cannot use evaluateHidden. */
+  readonly hiddenChecks?: readonly PythonHiddenCheck[];
   readonly workItemId: string;
   readonly plannedSymbolId: string;
   readonly qualifiedName: string;

--- a/bench/src/code-quality-eval/kontext-state.ts
+++ b/bench/src/code-quality-eval/kontext-state.ts
@@ -97,7 +97,8 @@ function assembly(
   };
 }
 
-function languageForPath(filePath: string): "typescript" | "javascript" {
+function languageForPath(filePath: string): "typescript" | "javascript" | "python" {
+  if (/\.py$/i.test(filePath)) return "python";
   return /\.[cm]?jsx?$/i.test(filePath) ? "javascript" : "typescript";
 }
 

--- a/bench/src/code-quality-eval/scenarios-multi-language.ts
+++ b/bench/src/code-quality-eval/scenarios-multi-language.ts
@@ -1,0 +1,429 @@
+import { callAssertion, requiredFunction, throwAssertion } from "./assertions.js";
+import type { CodeQualityScenario } from "./contracts.js";
+
+/**
+ * The JavaScript scenarios all target one exported function in one file, which
+ * leaves the provider's type-aware identity and its non-function symbol kinds
+ * untested. These add TypeScript scenarios that carry real annotations and a
+ * class method, plus Python scenarios that exercise the syntactic provider.
+ */
+export const multiLanguageScenarios: readonly CodeQualityScenario[] = [
+  ledgerPostingScenario(),
+  membershipTierScenario(),
+  pythonPricingScenario(),
+  pythonQuorumScenario(),
+];
+
+/** TypeScript, exercising an annotated signature and a discriminated result. */
+function ledgerPostingScenario(): CodeQualityScenario {
+  return {
+    scenarioId: "ledger-posting",
+    taskId: "task:code-quality:ledger-posting",
+    intent: "Classify a ledger posting under the approved settlement policy.",
+    publicPrompt:
+      "Implement classifyPosting in src/policy.ts according to the current settlement policy. Keep the exported types and the public API stable, and run the tests.",
+    sourceFile: "src/policy.ts",
+    initialSource: `export type PostingOutcome = "settled" | "pending" | "rejected";
+
+export interface Posting {
+  readonly amountCents: number;
+  readonly clearedAt: string | null;
+  readonly disputed: boolean;
+}
+
+export function classifyPosting(_posting: Posting): PostingOutcome {
+  throw new Error("Not implemented");
+}
+`,
+    publicTestSource: `import assert from "node:assert/strict";
+import test from "node:test";
+import { classifyPosting } from "../src/policy.ts";
+
+test("a cleared undisputed posting settles", () => {
+  assert.equal(
+    classifyPosting({ amountCents: 100, clearedAt: "2026-03-01T00:00:00.000Z", disputed: false }),
+    "settled",
+  );
+});
+`,
+    workItemId: "work-item:ledger-posting",
+    plannedSymbolId: "planned-symbol:classify-posting",
+    qualifiedName: "classifyPosting",
+    capabilityId: "capability:ledger-posting",
+    canonicalTerms: ["DISPUTE_HOLD_CENTS"],
+    rules: [
+      {
+        kind: "decision",
+        recordId: "decision:settlement-policy",
+        revisionId: "revision:settlement-policy:1",
+        statement:
+          "classifyPosting returns 'rejected' only when amountCents is zero or negative. A disputed posting returns 'pending' regardless of clearedAt, except that a disputed posting at or below the 2500 cent dispute hold still settles when clearedAt is present. An undisputed posting returns 'settled' when clearedAt is present and 'pending' otherwise.",
+        evidenceId: "evidence:finance:settlement-policy",
+        evidenceText:
+          "Treasury approved auto-settling small disputed postings at or below the dispute hold because manual review costs more than the exposure.",
+      },
+      {
+        kind: "domain_term",
+        recordId: "domain-term:dispute-hold",
+        revisionId: "revision:dispute-hold:1",
+        term: "Dispute Hold",
+        definition:
+          "The amount at or below which a disputed posting still settles. Implementation code names this constant DISPUTE_HOLD_CENTS.",
+        avoid: ["small dispute limit"],
+        evidenceId: "evidence:domain:dispute-hold",
+        evidenceText: "The finance domain owner standardized Dispute Hold and DISPUTE_HOLD_CENTS.",
+      },
+      {
+        kind: "invariant",
+        recordId: "invariant:non-positive-rejected",
+        revisionId: "revision:non-positive-rejected:1",
+        statement: "A posting of zero or less is always rejected.",
+        evidenceId: "evidence:finance:non-positive",
+        evidenceText: "The ledger refuses to settle a non-positive posting under any condition.",
+      },
+    ],
+    evaluateHidden: async (module) => {
+      const classify = requiredFunction(module, "classifyPosting");
+      const cleared = "2026-03-01T00:00:00.000Z";
+      return {
+        assertions: [
+          callAssertion(
+            "small-dispute-still-settles",
+            classify,
+            [{ amountCents: 2500, clearedAt: cleared, disputed: true }],
+            "settled",
+          ),
+          callAssertion(
+            "large-dispute-pends",
+            classify,
+            [{ amountCents: 2501, clearedAt: cleared, disputed: true }],
+            "pending",
+          ),
+          callAssertion(
+            "uncleared-dispute-pends",
+            classify,
+            [{ amountCents: 100, clearedAt: null, disputed: true }],
+            "pending",
+          ),
+          callAssertion(
+            "zero-is-rejected-before-any-other-rule",
+            classify,
+            [{ amountCents: 0, clearedAt: cleared, disputed: false }],
+            "rejected",
+          ),
+          callAssertion(
+            "uncleared-undisputed-pends",
+            classify,
+            [{ amountCents: 100, clearedAt: null, disputed: false }],
+            "pending",
+          ),
+        ],
+      };
+    },
+  };
+}
+
+/** TypeScript, where the Planned Symbol is a class method rather than a function. */
+function membershipTierScenario(): CodeQualityScenario {
+  return {
+    scenarioId: "membership-tier",
+    taskId: "task:code-quality:membership-tier",
+    intent: "Resolve a membership tier under the approved retention policy.",
+    publicPrompt:
+      "Implement the resolve method of MembershipPolicy in src/policy.ts according to the current retention policy. Keep the class and its public API stable, and run the tests.",
+    sourceFile: "src/policy.ts",
+    initialSource: `export type MembershipTier = "standard" | "silver" | "gold";
+
+export class MembershipPolicy {
+  resolve(_monthsActive: number, _lifetimeSpendCents: number): MembershipTier {
+    throw new Error("Not implemented");
+  }
+}
+`,
+    publicTestSource: `import assert from "node:assert/strict";
+import test from "node:test";
+import { MembershipPolicy } from "../src/policy.ts";
+
+test("a new low-spend member is standard", () => {
+  assert.equal(new MembershipPolicy().resolve(1, 0), "standard");
+});
+`,
+    workItemId: "work-item:membership-tier",
+    plannedSymbolId: "planned-symbol:membership-policy-resolve",
+    qualifiedName: "MembershipPolicy.resolve",
+    capabilityId: "capability:membership-tier",
+    canonicalTerms: ["TENURE_CREDIT_CENTS"],
+    rules: [
+      {
+        kind: "decision",
+        recordId: "decision:membership-retention",
+        revisionId: "revision:membership-retention:1",
+        statement:
+          "MembershipPolicy.resolve adds a tenure credit of 1000 cents for every complete 12 months active to lifetimeSpendCents, then compares the credited total: 50000 or more is 'gold', 20000 or more is 'silver', otherwise 'standard'. Tenure alone never promotes a member without spend, because a credited total of zero stays standard. Negative inputs throw RangeError.",
+        evidenceId: "evidence:retention:membership",
+        evidenceText:
+          "The retention owner approved crediting tenure into the spend comparison rather than adding a separate tenure rule, so a long-tenured low-spend member is not promoted on tenure alone.",
+      },
+      {
+        kind: "domain_term",
+        recordId: "domain-term:tenure-credit",
+        revisionId: "revision:tenure-credit:1",
+        term: "Tenure Credit",
+        definition:
+          "The per-year spend credit granted for tenure. Implementation code names this constant TENURE_CREDIT_CENTS.",
+        avoid: ["loyalty bonus"],
+        evidenceId: "evidence:domain:tenure-credit",
+        evidenceText:
+          "The retention domain owner standardized Tenure Credit and TENURE_CREDIT_CENTS.",
+      },
+      {
+        kind: "invariant",
+        recordId: "invariant:tier-monotonic",
+        revisionId: "revision:tier-monotonic:1",
+        statement: "More spend at equal tenure never lowers a member's tier.",
+        evidenceId: "evidence:retention:monotonic",
+        evidenceText: "Retention requires tier assignment to be non-decreasing in spend.",
+      },
+    ],
+    evaluateHidden: async (module) => {
+      const PolicyClass = module.MembershipPolicy as new () => {
+        resolve(months: number, spend: number): string;
+      };
+      if (typeof PolicyClass !== "function") throw new Error("Missing MembershipPolicy export");
+      const resolve = (months: number, spend: number): unknown =>
+        new PolicyClass().resolve(months, spend);
+      const call = (...args: readonly unknown[]) => resolve(args[0] as number, args[1] as number);
+      return {
+        assertions: [
+          // 24 months credits 2000, so 48000 becomes 50000 and reaches gold.
+          callAssertion("tenure-credit-reaches-gold", call, [24, 48_000], "gold"),
+          callAssertion("just-below-gold-stays-silver", call, [24, 47_999], "silver"),
+          // Partial years grant nothing: 23 months credits 1000, not 1916.
+          callAssertion("partial-year-grants-nothing-extra", call, [23, 48_000], "silver"),
+          callAssertion("tenure-alone-stays-standard", call, [120, 0], "standard"),
+          throwAssertion("rejects-negative-spend", call, [12, -1], RangeError),
+        ],
+      };
+    },
+  };
+}
+
+/** Python, exercising the syntactic provider on a module-level function. */
+function pythonPricingScenario(): CodeQualityScenario {
+  return {
+    scenarioId: "python-volume-pricing",
+    taskId: "task:code-quality:python-volume-pricing",
+    intent: "Price a volume order under the approved tier policy.",
+    publicPrompt:
+      "Implement price_order in src/policy.py according to the current volume pricing policy. Keep the public API stable and run the tests.",
+    sourceFile: "src/policy.py",
+    initialSource: `def price_order(units, unit_price_cents):
+    raise NotImplementedError
+`,
+    publicTestSource: `import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from policy import price_order
+
+
+class PublicPricing(unittest.TestCase):
+    def test_single_unit_uses_the_list_price(self):
+        self.assertEqual(price_order(1, 1000), 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()
+`,
+    workItemId: "work-item:python-volume-pricing",
+    plannedSymbolId: "planned-symbol:price-order",
+    qualifiedName: "price_order",
+    capabilityId: "capability:python-volume-pricing",
+    canonicalTerms: ["MARGINAL_TIER_BREAKS"],
+    rules: [
+      {
+        kind: "decision",
+        recordId: "decision:volume-pricing",
+        revisionId: "revision:volume-pricing:1",
+        statement:
+          "price_order applies marginal tier pricing, not a single rate chosen by total volume. The first 10 units bill at full unit_price_cents, units 11 through 100 bill at 90 percent, and units beyond 100 bill at 80 percent. Each tier's subtotal is floored to whole cents independently before summing. units and unit_price_cents must be non-negative integers; otherwise raise ValueError.",
+        evidenceId: "evidence:pricing:volume-tiers",
+        evidenceText:
+          "The pricing owner approved marginal tiers so that crossing a break never lowers the total bill, which a whole-order discount would allow.",
+      },
+      {
+        kind: "domain_term",
+        recordId: "domain-term:marginal-tier-break",
+        revisionId: "revision:marginal-tier-break:1",
+        term: "Marginal Tier Break",
+        definition:
+          "A unit count at which the marginal rate changes. Implementation code names this table MARGINAL_TIER_BREAKS.",
+        avoid: ["discount table"],
+        evidenceId: "evidence:domain:marginal-tier-break",
+        evidenceText:
+          "The pricing domain owner standardized Marginal Tier Break and MARGINAL_TIER_BREAKS.",
+      },
+      {
+        kind: "invariant",
+        recordId: "invariant:pricing-monotonic",
+        revisionId: "revision:pricing-monotonic:1",
+        statement: "Ordering one more unit never lowers the order total.",
+        evidenceId: "evidence:pricing:monotonic",
+        evidenceText: "Finance requires order totals to be non-decreasing in unit count.",
+      },
+    ],
+    hiddenChecks: [
+      // 10 at 1000 = 10000; the 11th unit bills at 900, so a whole-order
+      // discount would give 9900 instead of 10900.
+      {
+        assertionId: "eleventh-unit-is-marginal",
+        functionName: "price_order",
+        args: [11, 1000],
+        expected: 10_900,
+      },
+      {
+        assertionId: "tier-break-is-inclusive",
+        functionName: "price_order",
+        args: [10, 1000],
+        expected: 10_000,
+      },
+      {
+        assertionId: "third-tier-applies-beyond-one-hundred",
+        functionName: "price_order",
+        args: [101, 1000],
+        expected: 10_000 + 90 * 900 + 800,
+      },
+      {
+        assertionId: "zero-units-cost-nothing",
+        functionName: "price_order",
+        args: [0, 1000],
+        expected: 0,
+      },
+      {
+        assertionId: "floors-each-tier-independently",
+        functionName: "price_order",
+        args: [11, 5],
+        expected: 50 + 4,
+      },
+      {
+        assertionId: "rejects-negative-units",
+        functionName: "price_order",
+        args: [-1, 1000],
+        throws: "ValueError",
+      },
+    ],
+    evaluateHidden: async () => {
+      throw new Error("python-volume-pricing is evaluated through its Python driver");
+    },
+  };
+}
+
+/** Python, where the Planned Symbol is a method on a class. */
+function pythonQuorumScenario(): CodeQualityScenario {
+  return {
+    scenarioId: "python-approval-quorum",
+    taskId: "task:code-quality:python-approval-quorum",
+    intent: "Decide an approval quorum under the approved governance policy.",
+    publicPrompt:
+      "Implement quorum_met in src/policy.py according to the current approval policy. Keep the public API stable and run the tests.",
+    sourceFile: "src/policy.py",
+    initialSource: `def quorum_met(approvals, total_reviewers, risk):
+    raise NotImplementedError
+`,
+    publicTestSource: `import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from policy import quorum_met
+
+
+class PublicQuorum(unittest.TestCase):
+    def test_unanimous_low_risk_meets_quorum(self):
+        self.assertTrue(quorum_met(4, 4, "low"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+`,
+    workItemId: "work-item:python-approval-quorum",
+    plannedSymbolId: "planned-symbol:quorum-met",
+    qualifiedName: "quorum_met",
+    capabilityId: "capability:python-approval-quorum",
+    canonicalTerms: ["QUORUM_FLOOR"],
+    rules: [
+      {
+        kind: "decision",
+        recordId: "decision:approval-quorum",
+        revisionId: "revision:approval-quorum:1",
+        statement:
+          "quorum_met requires a strict majority for low risk and at least two thirds for high risk, both rounded up, and additionally never fewer than the quorum floor of 3 approvals for high risk. Low risk has no floor. A reviewer pool smaller than the required count can never meet quorum. approvals must not exceed total_reviewers and neither may be negative; otherwise raise ValueError.",
+        evidenceId: "evidence:governance:approval-quorum",
+        evidenceText:
+          "The governance owner approved an absolute floor of three approvals for high risk so that a two-person pool cannot approve a high-risk change by unanimity alone.",
+      },
+      {
+        kind: "domain_term",
+        recordId: "domain-term:quorum-floor",
+        revisionId: "revision:quorum-floor:1",
+        term: "Quorum Floor",
+        definition:
+          "The absolute minimum approvals for high risk regardless of pool size. Implementation code names this constant QUORUM_FLOOR.",
+        avoid: ["minimum approvals"],
+        evidenceId: "evidence:domain:quorum-floor",
+        evidenceText: "The governance domain owner standardized Quorum Floor and QUORUM_FLOOR.",
+      },
+      {
+        kind: "invariant",
+        recordId: "invariant:quorum-within-pool",
+        revisionId: "revision:quorum-within-pool:1",
+        statement: "Approvals never exceed the reviewer pool.",
+        evidenceId: "evidence:governance:pool-bound",
+        evidenceText: "The approval record cannot hold more approvals than reviewers.",
+      },
+    ],
+    hiddenChecks: [
+      // Two of two is unanimous but below the floor of three.
+      {
+        assertionId: "high-risk-floor-blocks-small-pool",
+        functionName: "quorum_met",
+        args: [2, 2, "high"],
+        expected: false,
+      },
+      {
+        assertionId: "high-risk-two-thirds-rounds-up",
+        functionName: "quorum_met",
+        args: [3, 4, "high"],
+        expected: true,
+      },
+      {
+        assertionId: "high-risk-below-two-thirds-fails",
+        functionName: "quorum_met",
+        args: [2, 4, "high"],
+        expected: false,
+      },
+      {
+        assertionId: "low-risk-has-no-floor",
+        functionName: "quorum_met",
+        args: [2, 2, "low"],
+        expected: true,
+      },
+      {
+        assertionId: "low-risk-needs-strict-majority",
+        functionName: "quorum_met",
+        args: [2, 4, "low"],
+        expected: false,
+      },
+      {
+        assertionId: "rejects-approvals-above-pool",
+        functionName: "quorum_met",
+        args: [5, 4, "low"],
+        throws: "ValueError",
+      },
+    ],
+    evaluateHidden: async () => {
+      throw new Error("python-approval-quorum is evaluated through its Python driver");
+    },
+  };
+}

--- a/bench/src/code-quality-eval/scenarios-reference.ts
+++ b/bench/src/code-quality-eval/scenarios-reference.ts
@@ -210,6 +210,30 @@ export const referenceImplementations: Readonly<Record<string, ScenarioModule>> 
       return Math.max(0, Math.min(refilled, burstCapacityTokens));
     },
   },
+  "ledger-posting": {
+    classifyPosting(posting: {
+      amountCents: number;
+      clearedAt: string | null;
+      disputed: boolean;
+    }): string {
+      const DISPUTE_HOLD_CENTS = 2500;
+      if (posting.amountCents <= 0) return "rejected";
+      if (posting.disputed && posting.amountCents > DISPUTE_HOLD_CENTS) return "pending";
+      return posting.clearedAt ? "settled" : "pending";
+    },
+  },
+  "membership-tier": {
+    MembershipPolicy: class {
+      resolve(monthsActive: number, lifetimeSpendCents: number): string {
+        const TENURE_CREDIT_CENTS = 1_000;
+        if (monthsActive < 0 || lifetimeSpendCents < 0) throw new RangeError("negative input");
+        const credited = lifetimeSpendCents + Math.floor(monthsActive / 12) * TENURE_CREDIT_CENTS;
+        if (credited >= 50_000) return "gold";
+        if (credited >= 20_000) return "silver";
+        return "standard";
+      }
+    },
+  },
 };
 
 export const naiveImplementations: Readonly<Record<string, ScenarioModule>> = {
@@ -315,6 +339,28 @@ export const naiveImplementations: Readonly<Record<string, ScenarioModule>> = {
       const elapsedMinutes = (nowMs - state.lastRefillMs) / 60_000;
       const refilled = state.tokens + elapsedMinutes * state.sustainedPerMinute;
       return Math.min(Math.round(refilled), state.burstCapacity);
+    },
+  },
+  // Treating any dispute as blocking is the intuitive reading.
+  "ledger-posting": {
+    classifyPosting(posting: {
+      amountCents: number;
+      clearedAt: string | null;
+      disputed: boolean;
+    }): string {
+      if (posting.amountCents <= 0) return "rejected";
+      if (posting.disputed) return "pending";
+      return posting.clearedAt ? "settled" : "pending";
+    },
+  },
+  // Comparing raw spend and treating tenure as its own rule is the obvious split.
+  "membership-tier": {
+    MembershipPolicy: class {
+      resolve(monthsActive: number, lifetimeSpendCents: number): string {
+        if (lifetimeSpendCents >= 50_000 || monthsActive >= 60) return "gold";
+        if (lifetimeSpendCents >= 20_000 || monthsActive >= 24) return "silver";
+        return "standard";
+      }
     },
   },
 };

--- a/bench/src/code-quality-eval/scenarios-validity.test.ts
+++ b/bench/src/code-quality-eval/scenarios-validity.test.ts
@@ -1,11 +1,47 @@
+import { execFile } from "node:child_process";
 import { rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
 import { naiveImplementations, referenceImplementations } from "./scenarios-reference.js";
 import { codeQualityScenarios } from "./scenarios.js";
-import { createScenarioWorkspace, evaluateWorkspace } from "./workspace.js";
+import { createScenarioWorkspace } from "./workspace.js";
 
+const execFileAsync = promisify(execFile);
 const temporaryDirectories: string[] = [];
+const benchDirectory = fileURLToPath(new URL("../..", import.meta.url));
+
+/**
+ * Evaluates in a child process rather than importing the module here. The real
+ * harness runs under plain node, where a workspace .ts file loads natively,
+ * while Vitest's transform pipeline refuses a file outside the project root.
+ * Running the module out of process also keeps model-generated code out of the
+ * evaluator.
+ */
+async function evaluateOutOfProcess(
+  scenarioId: string,
+  workspacePath: string,
+): Promise<{ publicTestsPassed: boolean; failed: string[] }> {
+  const script = `
+    const { evaluateWorkspace } = await import("./src/code-quality-eval/workspace.ts");
+    const { codeQualityScenarios } = await import("./src/code-quality-eval/scenarios.ts");
+    const scenario = codeQualityScenarios.find((item) => item.scenarioId === ${JSON.stringify(scenarioId)});
+    const result = await evaluateWorkspace(scenario, ${JSON.stringify(workspacePath)});
+    process.stdout.write(JSON.stringify({
+      publicTestsPassed: result.publicTestsPassed,
+      failed: result.hidden.assertions
+        .filter((assertion) => !assertion.passed)
+        .map((assertion) => assertion.assertionId + ": " + (assertion.diagnostic ?? "")),
+    }));
+  `;
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "-e", script],
+    { cwd: benchDirectory, encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
+  );
+  return JSON.parse(stdout) as { publicTestsPassed: boolean; failed: string[] };
+}
 
 afterAll(async () => {
   await Promise.all(
@@ -25,14 +61,142 @@ async function writeImplementation(
   sourceFile: string,
   implementation: Readonly<Record<string, unknown>>,
 ): Promise<void> {
-  const names = Object.keys(implementation);
-  const methods = names.map((name) => String(implementation[name])).join(",\n");
-  const exports = names.map((name) => `export const ${name} = __impl.${name};`).join("\n");
-  await writeFile(
-    path.join(workspacePath, sourceFile),
-    `const __impl = {\n${methods}\n};\n${exports}\n`,
-  );
+  // A class stringifies as a valid expression, but a method shorthand does not,
+  // so only the latter is rebuilt inside an object literal.
+  const parts = Object.entries(implementation).map(([name, value]) => {
+    const source = String(value);
+    return source.startsWith("class")
+      ? `export const ${name} = ${source};`
+      : `const __${name} = {\n${source}\n};\nexport const ${name} = __${name}.${name};`;
+  });
+  await writeFile(path.join(workspacePath, sourceFile), `${parts.join("\n")}\n`);
 }
+
+async function writeSource(
+  workspacePath: string,
+  sourceFile: string,
+  source: string,
+): Promise<void> {
+  await writeFile(path.join(workspacePath, sourceFile), source);
+}
+
+/**
+ * Implementations that cannot be recovered by stringifying a live function
+ * carry their source text instead. Python has no JavaScript function to
+ * stringify, and a TypeScript function stringifies with the transpiler's
+ * injected helpers, which do not exist in the workspace.
+ */
+const sourceImplementations: Readonly<
+  Record<string, { readonly reference: string; readonly naive: string }>
+> = {
+  "ledger-posting": {
+    reference: `const DISPUTE_HOLD_CENTS = 2500;
+
+export type PostingOutcome = "settled" | "pending" | "rejected";
+
+export interface Posting {
+  readonly amountCents: number;
+  readonly clearedAt: string | null;
+  readonly disputed: boolean;
+}
+
+export function classifyPosting(posting: Posting): PostingOutcome {
+  if (posting.amountCents <= 0) return "rejected";
+  if (posting.disputed && posting.amountCents > DISPUTE_HOLD_CENTS) return "pending";
+  return posting.clearedAt ? "settled" : "pending";
+}
+`,
+    naive: `export type PostingOutcome = "settled" | "pending" | "rejected";
+
+export interface Posting {
+  readonly amountCents: number;
+  readonly clearedAt: string | null;
+  readonly disputed: boolean;
+}
+
+export function classifyPosting(posting: Posting): PostingOutcome {
+  if (posting.amountCents <= 0) return "rejected";
+  if (posting.disputed) return "pending";
+  return posting.clearedAt ? "settled" : "pending";
+}
+`,
+  },
+  "membership-tier": {
+    reference: `const TENURE_CREDIT_CENTS = 1000;
+
+export type MembershipTier = "standard" | "silver" | "gold";
+
+export class MembershipPolicy {
+  resolve(monthsActive: number, lifetimeSpendCents: number): MembershipTier {
+    if (monthsActive < 0 || lifetimeSpendCents < 0) throw new RangeError("negative input");
+    const credited = lifetimeSpendCents + Math.floor(monthsActive / 12) * TENURE_CREDIT_CENTS;
+    if (credited >= 50000) return "gold";
+    if (credited >= 20000) return "silver";
+    return "standard";
+  }
+}
+`,
+    naive: `export type MembershipTier = "standard" | "silver" | "gold";
+
+export class MembershipPolicy {
+  resolve(monthsActive: number, lifetimeSpendCents: number): MembershipTier {
+    if (lifetimeSpendCents >= 50000 || monthsActive >= 60) return "gold";
+    if (lifetimeSpendCents >= 20000 || monthsActive >= 24) return "silver";
+    return "standard";
+  }
+}
+`,
+  },
+  "python-volume-pricing": {
+    reference: `MARGINAL_TIER_BREAKS = ((10, 100), (100, 90), (None, 80))
+
+
+def price_order(units, unit_price_cents):
+    if not isinstance(units, int) or isinstance(units, bool) or units < 0:
+        raise ValueError("invalid units")
+    if not isinstance(unit_price_cents, int) or unit_price_cents < 0:
+        raise ValueError("invalid price")
+    total = 0
+    remaining = units
+    previous = 0
+    for limit, percent in MARGINAL_TIER_BREAKS:
+        span = remaining if limit is None else min(remaining, limit - previous)
+        if span <= 0:
+            break
+        total += (span * unit_price_cents * percent) // 100
+        remaining -= span
+        previous = limit if limit is not None else previous
+    return total
+`,
+    naive: `def price_order(units, unit_price_cents):
+    if units > 100:
+        percent = 80
+    elif units > 10:
+        percent = 90
+    else:
+        percent = 100
+    return (units * unit_price_cents * percent) // 100
+`,
+  },
+  "python-approval-quorum": {
+    reference: `QUORUM_FLOOR = 3
+
+
+def quorum_met(approvals, total_reviewers, risk):
+    if approvals < 0 or total_reviewers < 0 or approvals > total_reviewers:
+        raise ValueError("invalid approvals")
+    if risk == "high":
+        required = max(QUORUM_FLOOR, -(-total_reviewers * 2 // 3))
+    else:
+        required = total_reviewers // 2 + 1
+    return approvals >= required
+`,
+    naive: `def quorum_met(approvals, total_reviewers, risk):
+    ratio = 2 / 3 if risk == "high" else 0.5
+    return approvals > total_reviewers * ratio
+`,
+  },
+};
 
 describe("code-quality scenarios are valid benchmark items", () => {
   it("covers enough scenarios for the harness pilot threshold", () => {
@@ -72,42 +236,54 @@ describe("code-quality scenarios are valid benchmark items", () => {
 
   for (const scenario of codeQualityScenarios) {
     it(`${scenario.scenarioId}: the policy-correct implementation passes everything`, async () => {
+      const sourceForm = sourceImplementations[scenario.scenarioId];
       const implementation = referenceImplementations[scenario.scenarioId];
-      expect(implementation, `missing reference for ${scenario.scenarioId}`).toBeDefined();
+      expect(
+        sourceForm ?? implementation,
+        `missing reference for ${scenario.scenarioId}`,
+      ).toBeDefined();
       const workspace = await createScenarioWorkspace(scenario);
       temporaryDirectories.push(workspace.workspacePath);
-      await writeImplementation(
-        workspace.workspacePath,
-        scenario.sourceFile,
-        implementation as Readonly<Record<string, unknown>>,
-      );
+      if (sourceForm) {
+        await writeSource(workspace.workspacePath, scenario.sourceFile, sourceForm.reference);
+      } else {
+        await writeImplementation(
+          workspace.workspacePath,
+          scenario.sourceFile,
+          implementation as Readonly<Record<string, unknown>>,
+        );
+      }
 
-      const result = await evaluateWorkspace(scenario, workspace.workspacePath);
+      const result = await evaluateOutOfProcess(scenario.scenarioId, workspace.workspacePath);
       expect(result.publicTestsPassed).toBe(true);
-      const failed = result.hidden.assertions.filter((assertion) => !assertion.passed);
-      expect(
-        failed.map((assertion) => `${assertion.assertionId}: ${assertion.diagnostic ?? ""}`),
-      ).toEqual([]);
+      expect(result.failed).toEqual([]);
     });
 
     it(`${scenario.scenarioId}: the naive implementation passes the public test but not the policy`, async () => {
+      const sourceForm = sourceImplementations[scenario.scenarioId];
       const implementation = naiveImplementations[scenario.scenarioId];
-      expect(implementation, `missing naive impl for ${scenario.scenarioId}`).toBeDefined();
+      expect(
+        sourceForm ?? implementation,
+        `missing naive impl for ${scenario.scenarioId}`,
+      ).toBeDefined();
       const workspace = await createScenarioWorkspace(scenario);
       temporaryDirectories.push(workspace.workspacePath);
-      await writeImplementation(
-        workspace.workspacePath,
-        scenario.sourceFile,
-        implementation as Readonly<Record<string, unknown>>,
-      );
+      if (sourceForm) {
+        await writeSource(workspace.workspacePath, scenario.sourceFile, sourceForm.naive);
+      } else {
+        await writeImplementation(
+          workspace.workspacePath,
+          scenario.sourceFile,
+          implementation as Readonly<Record<string, unknown>>,
+        );
+      }
 
-      const result = await evaluateWorkspace(scenario, workspace.workspacePath);
+      const result = await evaluateOutOfProcess(scenario.scenarioId, workspace.workspacePath);
       // The public surface must not reveal the policy, so the natural
       // implementation has to satisfy it.
       expect(result.publicTestsPassed).toBe(true);
       // And it must leave real headroom, or the scenario measures nothing.
-      const failed = result.hidden.assertions.filter((assertion) => !assertion.passed);
-      expect(failed.length).toBeGreaterThan(0);
+      expect(result.failed.length).toBeGreaterThan(0);
     });
   }
 });

--- a/bench/src/code-quality-eval/scenarios.test.ts
+++ b/bench/src/code-quality-eval/scenarios.test.ts
@@ -3,8 +3,15 @@ import { referenceImplementations } from "./scenarios-reference.js";
 import { codeQualityScenarios } from "./scenarios.js";
 
 describe("code-quality hidden evaluators", () => {
-  it("accepts implementations that satisfy every held-out policy", async () => {
-    for (const scenario of codeQualityScenarios) {
+  // Python scenarios declare hiddenChecks and are executed by their driver, and
+  // scenarios-validity.test.ts covers every scenario end to end in a real
+  // workspace. This case keeps the in-process JavaScript evaluators honest.
+  it("accepts JavaScript implementations that satisfy every held-out policy", async () => {
+    const inProcess = codeQualityScenarios.filter(
+      (scenario) => scenario.sourceFile.endsWith(".js") && !scenario.hiddenChecks,
+    );
+    expect(inProcess.length).toBeGreaterThan(0);
+    for (const scenario of inProcess) {
       const implementation = referenceImplementations[scenario.scenarioId];
       if (!implementation) throw new Error(`Missing implementation for ${scenario.scenarioId}`);
       const result = await scenario.evaluateHidden(implementation);

--- a/bench/src/code-quality-eval/scenarios.ts
+++ b/bench/src/code-quality-eval/scenarios.ts
@@ -1,12 +1,14 @@
 import { callAssertion, requiredFunction, throwAssertion } from "./assertions.js";
 import type { CodeQualityScenario } from "./contracts.js";
 import { extendedCodeQualityScenarios } from "./scenarios-extended.js";
+import { multiLanguageScenarios } from "./scenarios-multi-language.js";
 
 export const codeQualityScenarios: readonly CodeQualityScenario[] = [
   retryPolicyScenario(),
   cancellationScenario(),
   serviceCreditScenario(),
   ...extendedCodeQualityScenarios,
+  ...multiLanguageScenarios,
 ];
 
 function retryPolicyScenario(): CodeQualityScenario {

--- a/bench/src/code-quality-eval/workspace.ts
+++ b/bench/src/code-quality-eval/workspace.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -35,14 +35,14 @@ export async function createScenarioWorkspace(
         version: "1.0.0",
         private: true,
         type: "module",
-        scripts: { test: "node --test" },
+        scripts: { test: testCommand(scenario) },
       },
       null,
       2,
     )}\n`,
   );
   await writeFile(path.join(workspacePath, scenario.sourceFile), scenario.initialSource);
-  await writeFile(path.join(workspacePath, "test", "public.test.js"), scenario.publicTestSource);
+  await writeFile(path.join(workspacePath, testFileFor(scenario)), scenario.publicTestSource);
   await writeFile(
     path.join(workspacePath, "TASK.md"),
     `# Task\n\n${scenario.publicPrompt}\n\nOnly edit \`${scenario.sourceFile}\`.\n`,
@@ -64,6 +64,25 @@ export async function createScenarioWorkspace(
   };
 }
 
+export function isPythonScenario(scenario: CodeQualityScenario): boolean {
+  return /\.py$/i.test(scenario.sourceFile);
+}
+
+export function testFileFor(scenario: CodeQualityScenario): string {
+  return (
+    scenario.testFile ??
+    (isPythonScenario(scenario) ? "test/public_test.py" : "test/public.test.js")
+  );
+}
+
+function testCommand(scenario: CodeQualityScenario): string {
+  // Python has no npm test runner, so the workspace script shells out to
+  // unittest while keeping one uniform `npm test` entry point for the agent.
+  // unittest discovery needs the start directory to be an importable package,
+  // so the workspace runs the test module directly instead.
+  return isPythonScenario(scenario) ? `python3 ${testFileFor(scenario)}` : "node --test";
+}
+
 export async function evaluateWorkspace(
   scenario: CodeQualityScenario,
   workspacePath: string,
@@ -74,18 +93,24 @@ export async function evaluateWorkspace(
   readonly changedPaths: readonly string[];
   readonly patch: string;
 }> {
-  const publicTests = await runWorkspaceCommand(workspacePath, "npm", [
-    "test",
-    "--",
-    "--test-reporter=spec",
-  ]);
+  // --test-reporter is a node --test flag; unittest rejects it as an unknown
+  // argument and the public test would look like a failure.
+  const publicTests = await runWorkspaceCommand(
+    workspacePath,
+    "npm",
+    isPythonScenario(scenario) ? ["test"] : ["test", "--", "--test-reporter=spec"],
+  );
   const sourcePath = path.join(workspacePath, scenario.sourceFile);
   const source = await readFile(sourcePath, "utf8").catch(() => "");
   let hidden: HiddenEvaluationResult;
   try {
-    const moduleUrl = `${pathToFileURL(sourcePath).href}?eval=${Date.now()}-${Math.random()}`;
-    const loaded = (await import(moduleUrl)) as Readonly<Record<string, unknown>>;
-    hidden = await scenario.evaluateHidden(loaded);
+    hidden = isPythonScenario(scenario)
+      ? await evaluatePythonChecks(scenario, workspacePath)
+      : await (async () => {
+          const moduleUrl = `${pathToFileURL(sourcePath).href}?eval=${Date.now()}-${Math.random()}`;
+          const loaded = (await import(moduleUrl)) as Readonly<Record<string, unknown>>;
+          return scenario.evaluateHidden(loaded);
+        })();
   } catch (error) {
     hidden = {
       assertions: [
@@ -111,6 +136,94 @@ export async function evaluateWorkspace(
     patch,
   };
 }
+
+/**
+ * Held-out checks for a Python scenario are declared as data and executed by a
+ * driver inside the workspace, because the evaluator cannot import a Python
+ * module the way it imports a JavaScript one. The driver is written outside the
+ * repository tree under test and removed afterwards so it never appears as a
+ * changed path.
+ */
+async function evaluatePythonChecks(
+  scenario: CodeQualityScenario,
+  workspacePath: string,
+): Promise<HiddenEvaluationResult> {
+  const checks = scenario.hiddenChecks;
+  if (!checks || checks.length === 0) {
+    throw new Error(`Python scenario ${scenario.scenarioId} declares no hidden checks`);
+  }
+  const driverDirectory = await mkdtemp(path.join(tmpdir(), "kontext-python-driver-"));
+  const driverPath = path.join(driverDirectory, "driver.py");
+  const specPath = path.join(driverDirectory, "checks.json");
+  const moduleDirectory = path.join(workspacePath, path.dirname(scenario.sourceFile));
+  const moduleName = path.basename(scenario.sourceFile).replace(/\.py$/i, "");
+  await writeFile(specPath, JSON.stringify({ checks }), "utf8");
+  await writeFile(driverPath, pythonDriverSource, "utf8");
+  try {
+    const result = await runWorkspaceCommand(workspacePath, "python3", [
+      driverPath,
+      moduleDirectory,
+      moduleName,
+      specPath,
+    ]);
+    const parsed = JSON.parse(result.stdout) as HiddenEvaluationResult;
+    return parsed;
+  } finally {
+    await rm(driverDirectory, { recursive: true, force: true });
+  }
+}
+
+const pythonDriverSource = `import importlib.util, json, sys
+
+module_directory, module_name, spec_path = sys.argv[1], sys.argv[2], sys.argv[3]
+sys.path.insert(0, module_directory)
+with open(spec_path) as handle:
+    checks = json.load(handle)["checks"]
+
+assertions = []
+try:
+    spec = importlib.util.spec_from_file_location(
+        module_name, module_directory + "/" + module_name + ".py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+except Exception as error:
+    print(json.dumps({"assertions": [
+        {"assertionId": "module-load", "passed": False,
+         "diagnostic": type(error).__name__ + ": " + str(error)}
+    ]}))
+    sys.exit(0)
+
+for check in checks:
+    assertion_id = check["assertionId"]
+    try:
+        function = getattr(module, check["functionName"])
+    except AttributeError:
+        assertions.append({"assertionId": assertion_id, "passed": False,
+                           "diagnostic": "Missing function " + check["functionName"]})
+        continue
+    expects_throw = check.get("throws")
+    try:
+        actual = function(*check["args"])
+        if expects_throw:
+            assertions.append({"assertionId": assertion_id, "passed": False,
+                               "diagnostic": "Expected " + expects_throw})
+        elif actual == check.get("expected"):
+            assertions.append({"assertionId": assertion_id, "passed": True})
+        else:
+            assertions.append({"assertionId": assertion_id, "passed": False,
+                               "diagnostic": "Expected " + json.dumps(check.get("expected")) +
+                                             ", received " + repr(actual)})
+    except Exception as error:
+        name = type(error).__name__
+        if expects_throw and name == expects_throw:
+            assertions.append({"assertionId": assertion_id, "passed": True})
+        else:
+            assertions.append({"assertionId": assertion_id, "passed": False,
+                               "diagnostic": name + ": " + str(error)})
+
+print(json.dumps({"assertions": assertions}))
+`;
 
 export async function runWorkspaceCommand(
   cwd: string,


### PR DESCRIPTION
Follows #22, which taught the product to analyze Python.

## Why

The catalogue was homogeneous:

```
distinct source files: [ 'src/policy.js' ]
all single pure function: true
kind: "function"   ← all ten
```

That leaves the provider's type-aware identity untested, and it is exactly the mechanism behind the `identity_ambiguous` defect fixed in #17 — `signatureDiscriminator` carries the inferred type signature, which is largely inert in unannotated JavaScript.

## Added

| scenario | language | exercises |
|---|---|---|
| `ledger-posting` | TypeScript | annotated signature, exported types, threshold inside a branch |
| `membership-tier` | TypeScript | Planned Symbol is a **class method**, not a function |
| `python-volume-pricing` | Python | marginal tiers vs a whole-order rate |
| `python-approval-quorum` | Python | proportion plus an absolute floor |

Now 14 scenarios: 10 JavaScript, 2 TypeScript, 2 Python.

## Harness changes

- Test file extension and the `npm test` script depend on scenario language.
- `unittest discover` needs the start directory to be an importable package, so the workspace runs the test module directly.
- `--test-reporter=spec` is a `node --test` flag; passing it to unittest made every Python public test look like a failure.
- Python held-out checks are declared as data and executed by a driver written outside the workspace and removed afterwards, so it never appears as a changed path.

## Validity suite now evaluates out of process

The real harness runs under plain node, where a workspace `.ts` file loads natively. Vitest's transform pipeline refuses a file outside the project root, which made passing TypeScript scenarios look broken. Verified against the real runtime:

```
public= true hidden fails= []
```

Evaluating in a child process also keeps model-generated code out of the evaluator, which the previous in-process `import()` did not.

Implementations that cannot be recovered by stringifying a live function now carry source text. A TypeScript function stringifies with the transpiler's injected `__name` helpers, which do not exist in the workspace — that produced `__name is not defined` rather than an honest failure.

## Validation

All 28 per-scenario validity checks pass: for every scenario the policy-correct implementation passes the public test and every hidden assertion, and the naive implementation passes the public test and fails at least one hidden assertion.

- `tsc -p bench/tsconfig.code-quality.json`
- code-quality suite: 51 passed
- repository suite: 351 passed, 14 skipped
- `biome check bench/src/code-quality-eval`

🤖 Generated with [Claude Code](https://claude.com/claude-code)