### PR TITLE
fix: load .env.local before the retrieval arm needs its key

### DIFF
--- a/bench/src/code-quality-eval/cli.ts
+++ b/bench/src/code-quality-eval/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { existsSync } from "node:fs";
 import { access, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,6 +18,10 @@ async function main(): Promise<void> {
     return;
   }
   const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+  // The retrieval arm embeds its corpus through the shared OpenAI client, which
+  // reads its key the same way the rag-eval-v2 CLI does.
+  const localEnvironment = path.join(repositoryRoot, ".env.local");
+  if (existsSync(localEnvironment)) process.loadEnvFile(localEnvironment);
   const options = parseOptions(process.argv.slice(2), repositoryRoot);
   await verifyBuiltArtifacts(repositoryRoot);
   const report = await runCodeQualityEvaluation({


### PR DESCRIPTION
A three-arm run aborted on its first scenario:

```
[retry-policy r1] rag starting
Error: The retrieval arm requires OPENAI_API_KEY for corpus embeddings
```

The retrieval arm embeds its corpus through the shared OpenAI client, but the code-quality CLI never loaded `.env.local`. The `rag-eval-v2` CLI already loads it the same way; this brings the two into line.

## Validation

- `tsc -p bench/tsconfig.code-quality.json`
- code-quality suite: 51 passed
- `biome check bench/src/code-quality-eval`

🤖 Generated with [Claude Code](https://claude.com/claude-code)